### PR TITLE
Bump CI Node to 22 so astro build stops erroring out

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
## What broke
The [Deploy to GitHub Pages run](https://github.com/ibennet/izzybennett.com/actions/runs/30657528131) failed at `npm run build`:

```
Node.js v20.20.2 is not supported by Astro!
Please upgrade Node.js to a supported version: ">=22.12.0"
```

Astro 7 (and `package.json`'s own `engines.node: ">=22.12.0"`) require Node 22.12+, but the Pages workflow was still provisioning `node-version: 20`.

## The fix
Bumped `setup-node` to `node-version: 22` in `.github/workflows/deploy.yml`. `22` resolves to the latest 22.x, comfortably above the 22.12.0 floor.

## Verification
Ran `npm ci` + `npm run build` locally on Node 22+ — clean build, 23 pages generated, `Complete!`. No more engine error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)