### PR TITLE
feat: markdownmaxxing recipe steps so **bold** actually renders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tailwindcss/typography": "^0.5.20",
         "@tailwindcss/vite": "^4.3.3",
         "astro": "^7.1.6",
+        "marked": "^18.0.7",
         "tailwindcss": "^4.3.3"
       },
       "devDependencies": {
@@ -4289,6 +4290,18 @@
         "@babel/parser": "^7.29.7",
         "@babel/types": "^7.29.7",
         "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.7.tgz",
+      "integrity": "sha512-iDVQ5ldaiKXn6b2JroX5kgRfmwgqolW7NpaEzTl1k/2Zh1njIEN9yniyLV/mOvWwtsE8OGgkjsCYvijuPk1dtA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mdast-util-to-hast": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tailwindcss/typography": "^0.5.20",
     "@tailwindcss/vite": "^4.3.3",
     "astro": "^7.1.6",
+    "marked": "^18.0.7",
     "tailwindcss": "^4.3.3"
   },
   "devDependencies": {

--- a/src/layouts/RecipeLayout.astro
+++ b/src/layouts/RecipeLayout.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from './BaseLayout.astro';
 import type { CollectionEntry } from 'astro:content';
+import { inlineMarkdown } from '../lib/markdown';
 
 interface Props {
   recipe: CollectionEntry<'recipes'>;
@@ -82,7 +83,7 @@ const hasMeta = prepTime !== undefined || cookTime !== undefined || servings !==
             <span class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent-50 text-xs font-medium text-accent-700 dark:bg-neutral-800 dark:text-accent-100">
               {i + 1}
             </span>
-            <span class="text-neutral-700 dark:text-neutral-300">{step}</span>
+            <span class="text-neutral-700 dark:text-neutral-300" set:html={inlineMarkdown(step)} />
           </li>
         ))}
       </ol>

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,0 +1,7 @@
+import { marked } from 'marked';
+
+// Render a single line of inline markdown (bold/italic/code/links) to HTML.
+// parseInline avoids block-level <p> wrapping so it drops into inline spans.
+export function inlineMarkdown(text: string): string {
+  return marked.parseInline(text) as string;
+}

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,7 +1,9 @@
 import { marked } from 'marked';
 
 // Render a single line of inline markdown (bold/italic/code/links) to HTML.
-// parseInline avoids block-level <p> wrapping so it drops into inline spans.
+// parseInline avoids block-level <p> wrapping so it drops into inline spans;
+// { async: false } selects the sync overload so the return is a real string
+// (no cast) and a future async hook can't slip a Promise into set:html.
 export function inlineMarkdown(text: string): string {
-  return marked.parseInline(text) as string;
+  return marked.parseInline(text, { async: false });
 }

--- a/src/pages/upload.astro
+++ b/src/pages/upload.astro
@@ -112,6 +112,9 @@ const removeBtn =
             <h2 class={sectionHeading}>Steps <span class="text-accent-600">*</span></h2>
             <button type="button" data-action="add-step" class={addBtn}>+ Add</button>
           </div>
+          <p class="mt-1 text-xs text-neutral-500 dark:text-neutral-500">
+            Markdown supported — **bold**, *italic*, `code`, [links](url).
+          </p>
           <div id="steps-list" class="mt-2 space-y-2"></div>
         </section>
 

--- a/src/pages/upload.astro
+++ b/src/pages/upload.astro
@@ -112,7 +112,7 @@ const removeBtn =
             <h2 class={sectionHeading}>Steps <span class="text-accent-600">*</span></h2>
             <button type="button" data-action="add-step" class={addBtn}>+ Add</button>
           </div>
-          <p class="mt-1 text-xs text-neutral-500 dark:text-neutral-500">
+          <p class="mt-1 text-xs text-neutral-400">
             Markdown supported — **bold**, *italic*, `code`, [links](url).
           </p>
           <div id="steps-list" class="mt-2 space-y-2"></div>


### PR DESCRIPTION
## What & why
Izzy dropped `**...**` into the Cherry Tomato Pasta steps to bold some words, but it rendered as literal asterisks. Recipe `steps` are a frontmatter `string[]` that `RecipeLayout.astro` interpolated as escaped plain text — no markdown renderer existed anywhere in the project.

## Changes
- Add `marked` dep + a tiny `src/lib/markdown.ts` `inlineMarkdown()` helper using `marked.parseInline` (inline-only, no `<p>` wrapping — drops cleanly into the existing `<span>`).
- Render steps via `set:html={inlineMarkdown(step)}` in `RecipeLayout.astro`. Ingredients/notes/description stay plain text (scope: steps only).
- Add a "Markdown supported — **bold**, *italic*, `code`, links" hint under the Steps field in `upload.astro`.

Trust boundary: only the `ALLOWED_LOGIN`-gated owner authors recipes via the OAuth worker, so rendering their own trusted text with `set:html` is fine.

## Verification
- `npm run build` passes (25 pages).
- Temporarily injected a `**bold** *italic* \`code\`` step into a recipe → built HTML rendered `<strong>`/`<em>`/`<code>` correctly, then reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)