### PR TITLE
authmaxxing: swap recipe PAT paste-box for GitHub OAuth 🔐

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,11 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+        env:
+          # Base URL of the recipe API Worker (the /upload OAuth backend). Set this once in
+          # repo Settings → Secrets and variables → Actions → Variables as PUBLIC_RECIPE_API,
+          # e.g. https://izzy-recipe-api.<subdomain>.workers.dev
+          PUBLIC_RECIPE_API: ${{ vars.PUBLIC_RECIPE_API }}
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ dist/
 # dependencies
 node_modules/
 
+# cloudflare worker
+.wrangler/
+worker/.dev.vars
+
 # logs
 npm-debug.log*
 yarn-debug.log*

--- a/src/pages/recipes.json.ts
+++ b/src/pages/recipes.json.ts
@@ -1,0 +1,22 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+
+// Build-time JSON index of every published recipe's frontmatter, keyed by slug. Consumed
+// client-side by the uploader (/upload) to populate its "load existing recipe" picker and to
+// pre-fill the form when editing. Recipes carry no markdown body — all content lives in
+// frontmatter — so `data` + slug is the complete record.
+//
+// Drafts are excluded so a draft's data isn't publicly fetchable at this URL (this file is
+// static and unauthenticated, like the rest of the site). The trade-off: drafts can't be
+// edited through /upload — edit them directly in the repo. Drafts have no detail page or
+// index card either, so they have no UI edit surface anyway.
+export const GET: APIRoute = async () => {
+  const recipes = await getCollection('recipes', ({ data }) => !data.draft);
+  const payload = recipes
+    .map((recipe) => ({ slug: recipe.id, ...recipe.data }))
+    .sort((a, b) => a.title.localeCompare(b.title));
+
+  return new Response(JSON.stringify(payload), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/src/pages/upload.astro
+++ b/src/pages/upload.astro
@@ -1,0 +1,749 @@
+---
+// Standalone, unlisted recipe uploader. Not linked from Nav and deliberately does NOT
+// use BaseLayout so it stays out of the site chrome. It builds a schema-valid markdown
+// file client-side, then hands it to the recipe API Worker, which — after a GitHub OAuth
+// sign-in — commits it to the repo on your behalf. The GitHub token never reaches the
+// browser; this page only ever holds an opaque session id. Commits trigger the normal
+// GitHub Pages deploy. See /worker for the backend.
+import '../styles/global.css';
+import { categoryValues } from '../content.config';
+
+// Base URL of the recipe API Worker (the OAuth backend + write proxy). Injected at build
+// time; falls back to the local `wrangler dev` port so `astro dev` works out of the box.
+const RECIPE_API = import.meta.env.PUBLIC_RECIPE_API ?? 'http://localhost:8787';
+
+// Canonical site origin (from astro.config `site`), used to build the "it's live at…" link.
+const SITE_ORIGIN = import.meta.env.SITE ?? 'https://izzybennett.com';
+
+// Shared class strings, hoisted so a styling tweak happens in one place instead of ~14.
+const labelCls = 'block text-sm font-medium text-neutral-700 dark:text-neutral-300';
+const fieldInput =
+  'mt-1 w-full rounded-lg border border-neutral-300 bg-white px-3 py-2.5 text-neutral-900 placeholder:text-neutral-400 focus:border-accent-600 focus:outline-none focus:ring-2 focus:ring-accent-600/30 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100';
+const rowInput =
+  'min-w-0 flex-1 rounded-lg border border-neutral-300 bg-white px-3 py-2 text-neutral-900 placeholder:text-neutral-400 focus:border-accent-600 focus:outline-none focus:ring-2 focus:ring-accent-600/30 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100';
+const sectionHeading = 'text-sm font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-500';
+const addBtn =
+  'rounded-md px-2 py-1 text-sm font-medium text-accent-600 hover:bg-accent-50 dark:text-accent-100 dark:hover:bg-neutral-900';
+const removeBtn =
+  'shrink-0 rounded-lg border border-neutral-300 px-3 text-neutral-400 hover:border-red-400 hover:text-red-500 dark:border-neutral-700';
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow" />
+    <meta name="theme-color" content="#db2777" />
+    <link rel="icon" href="/favicon.ico" />
+    <title>Add a recipe · Izzy Bennett</title>
+  </head>
+  <body class="min-h-screen bg-white text-neutral-800 dark:bg-neutral-950 dark:text-neutral-200">
+    <main class="mx-auto w-full max-w-2xl px-4 py-8 sm:px-6">
+      <header class="flex items-baseline justify-between gap-3">
+        <h1 id="page-title" class="text-2xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">Add a recipe</h1>
+        <a href="/recipes/" class="text-sm text-accent-600 hover:underline dark:text-accent-100">← Recipes</a>
+      </header>
+      <p id="page-intro" class="mt-1 text-sm text-neutral-500 dark:text-neutral-500">Fill it in, hit publish, and it goes live in a minute or two.</p>
+
+      <!-- Auth bar. Sign-in kicks off GitHub OAuth on the Worker; on return the page holds
+           only an opaque session id (never a GitHub token). -->
+      <div class="mt-4 flex items-center gap-3 rounded-lg border border-neutral-200 bg-neutral-50 p-3 dark:border-neutral-800 dark:bg-neutral-900">
+        <span id="auth-state" class="text-sm text-neutral-500 dark:text-neutral-400">Checking sign-in…</span>
+        <a id="signin-btn" href={`${RECIPE_API}/login`}
+          class="ml-auto hidden rounded-lg bg-neutral-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-neutral-700 dark:bg-white dark:text-neutral-900 dark:hover:bg-neutral-200">
+          Sign in with GitHub
+        </a>
+        <button type="button" id="signout-btn"
+          class="ml-auto hidden rounded-lg border border-neutral-300 px-3 py-1.5 text-sm font-medium text-neutral-700 hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800">
+          Sign out
+        </button>
+      </div>
+
+      <!-- Pick an existing recipe to edit it, or keep "New recipe" to add a fresh one.
+           Populated from /recipes.json on load; selecting one switches the form to edit mode. -->
+      <div class="mt-4">
+        <label for="recipe-picker" class={labelCls}>Load existing recipe</label>
+        <select id="recipe-picker" class={fieldInput}>
+          <option value="">➕ New recipe</option>
+        </select>
+      </div>
+
+      <form id="recipe-form" class="mt-6 space-y-8" novalidate>
+        <!-- Basics -->
+        <section class="space-y-4">
+          <div>
+            <label for="title" class={labelCls}>Title <span class="text-accent-600">*</span></label>
+            <input id="title" name="title" type="text" required autocomplete="off" enterkeyhint="next" class={fieldInput} />
+          </div>
+
+          <div class="grid grid-cols-2 gap-3">
+            <div>
+              <label for="category" class={labelCls}>Category <span class="text-accent-600">*</span></label>
+              <select id="category" name="category" class={`${fieldInput} capitalize`}>
+                {categoryValues.map((c) => <option value={c}>{c}</option>)}
+              </select>
+            </div>
+            <div class="flex items-end pb-1">
+              <label class="inline-flex items-center gap-2 text-sm text-neutral-700 dark:text-neutral-300">
+                <input id="draft" name="draft" type="checkbox"
+                  class="h-4 w-4 rounded border-neutral-300 text-accent-600 focus:ring-accent-600/30 dark:border-neutral-700 dark:bg-neutral-900" />
+                Draft (hidden)
+              </label>
+            </div>
+          </div>
+
+          <div>
+            <label for="description" class={labelCls}>Description <span class="text-neutral-400">(optional)</span></label>
+            <input id="description" name="description" type="text" autocomplete="off" class={fieldInput} />
+          </div>
+
+          <div>
+            <label for="keywords" class={labelCls}>Keywords <span class="text-neutral-400">(comma-separated)</span></label>
+            <input id="keywords" name="keywords" type="text" autocomplete="off" placeholder="e.g. pie, apple, baking" class={fieldInput} />
+          </div>
+
+          <div class="grid grid-cols-3 gap-3">
+            <div>
+              <label for="prepTime" class={labelCls}>Prep <span class="text-neutral-400">min</span></label>
+              <input id="prepTime" name="prepTime" type="number" min="0" step="1" inputmode="numeric" class={fieldInput} />
+            </div>
+            <div>
+              <label for="cookTime" class={labelCls}>Cook <span class="text-neutral-400">min</span></label>
+              <input id="cookTime" name="cookTime" type="number" min="0" step="1" inputmode="numeric" class={fieldInput} />
+            </div>
+            <div>
+              <label for="servings" class={labelCls}>Servings</label>
+              <input id="servings" name="servings" type="number" min="1" step="1" inputmode="numeric" class={fieldInput} />
+            </div>
+          </div>
+        </section>
+
+        <!-- Tools -->
+        <section>
+          <div class="flex items-center justify-between">
+            <h2 class={sectionHeading}>Tools <span class="normal-case font-normal text-neutral-400">(optional)</span></h2>
+            <button type="button" data-action="add-tool" class={addBtn}>+ Add</button>
+          </div>
+          <div id="tools-list" class="mt-2 space-y-2"></div>
+        </section>
+
+        <!-- Ingredients -->
+        <section>
+          <div class="flex items-center justify-between">
+            <h2 class={sectionHeading}>Ingredients <span class="text-accent-600">*</span></h2>
+            <button type="button" data-action="add-group" class={addBtn}>+ Group</button>
+          </div>
+          <p class="mt-1 text-xs text-neutral-400">Group names are optional — leave blank for a plain list.</p>
+          <div id="ingredients-list" class="mt-2 space-y-4"></div>
+        </section>
+
+        <!-- Steps -->
+        <section>
+          <div class="flex items-center justify-between">
+            <h2 class={sectionHeading}>Steps <span class="text-accent-600">*</span></h2>
+            <button type="button" data-action="add-step" class={addBtn}>+ Add</button>
+          </div>
+          <div id="steps-list" class="mt-2 space-y-2"></div>
+        </section>
+
+        <!-- Notes -->
+        <section>
+          <div class="flex items-center justify-between">
+            <h2 class={sectionHeading}>Notes <span class="normal-case font-normal text-neutral-400">(optional)</span></h2>
+            <button type="button" data-action="add-note" class={addBtn}>+ Add</button>
+          </div>
+          <div id="notes-list" class="mt-2 space-y-2"></div>
+        </section>
+
+        <!-- Preview -->
+        <details id="preview-details" class="rounded-lg border border-neutral-200 dark:border-neutral-800">
+          <summary class="cursor-pointer px-3 py-2 text-sm font-medium text-neutral-700 dark:text-neutral-300">Preview markdown</summary>
+          <div class="border-t border-neutral-200 p-3 dark:border-neutral-800">
+            <pre id="preview" class="max-h-80 overflow-auto whitespace-pre-wrap rounded bg-neutral-50 p-3 text-xs text-neutral-700 dark:bg-neutral-900 dark:text-neutral-300">Fill in the form to see the generated file.</pre>
+            <button type="button" id="copy-md" class={`mt-2 ${addBtn}`}>Copy markdown</button>
+          </div>
+        </details>
+
+        <!-- Actions -->
+        <div class="sticky bottom-0 -mx-4 border-t border-neutral-200 bg-white/90 px-4 py-3 backdrop-blur sm:-mx-6 sm:px-6 dark:border-neutral-800 dark:bg-neutral-950/90">
+          <button type="submit" id="publish"
+            class="w-full rounded-lg bg-accent-600 px-4 py-3 text-center font-semibold text-white transition-colors hover:bg-accent-700 disabled:opacity-60">
+            Publish 🚀
+          </button>
+          <button type="button" id="delete-recipe"
+            class="mt-2 hidden w-full rounded-lg border border-red-300 px-4 py-2.5 text-center font-medium text-red-600 transition-colors hover:bg-red-50 disabled:opacity-60 dark:border-red-900 dark:text-red-400 dark:hover:bg-red-950/40">
+            Delete recipe
+          </button>
+          <p id="status" class="mt-2 text-sm" role="status" aria-live="polite"></p>
+        </div>
+      </form>
+    </main>
+
+    <!-- Row templates. tpl-row is the generic single-line input row (tools / notes /
+         ingredient items) — the JS stamps data-field + placeholder per use. -->
+    <template id="tpl-row">
+      <div data-unit="row" class="flex gap-2">
+        <input type="text" autocomplete="off" class={rowInput} />
+        <button type="button" data-action="remove" aria-label="Remove" class={removeBtn}>✕</button>
+      </div>
+    </template>
+
+    <template id="tpl-step">
+      <div data-unit="step" class="flex gap-2">
+        <textarea data-field="step" rows="2" placeholder="Describe the step…" class={rowInput}></textarea>
+        <button type="button" data-action="remove" aria-label="Remove" class={`${removeBtn} self-start py-2`}>✕</button>
+      </div>
+    </template>
+
+    <template id="tpl-group">
+      <div data-unit="group" class="rounded-lg border border-neutral-200 p-3 dark:border-neutral-800">
+        <div class="flex gap-2">
+          <input type="text" data-field="group" placeholder="Group name (optional), e.g. Pie Crust" autocomplete="off" class={`${rowInput} text-sm font-medium`} />
+          <button type="button" data-action="remove" aria-label="Remove group" class={removeBtn}>✕</button>
+        </div>
+        <div class="items-list mt-2 space-y-2"></div>
+        <button type="button" data-action="add-item" class={`mt-2 ${addBtn}`}>+ Ingredient</button>
+      </div>
+    </template>
+
+    <script define:vars={{ RECIPE_API, SITE_ORIGIN }}>
+      // ---- Config ---------------------------------------------------------
+      // RECIPE_API is injected from the frontmatter above. The browser only ever holds the
+      // opaque session id under SESSION_KEY — never a GitHub token.
+      const API = RECIPE_API;
+      const SESSION_KEY = 'izzy-recipe-session';
+
+      // ---- Element helpers ------------------------------------------------
+      const $ = (sel) => document.querySelector(sel);
+      const form = $('#recipe-form');
+      const statusEl = $('#status');
+      const previewEl = $('#preview');
+      const previewDetails = $('#preview-details');
+      const publishBtn = $('#publish');
+      const pageTitle = $('#page-title');
+      const pageIntro = $('#page-intro');
+      const picker = $('#recipe-picker');
+      const deleteBtn = $('#delete-recipe');
+      const authState = $('#auth-state');
+      const signinBtn = $('#signin-btn');
+      const signoutBtn = $('#signout-btn');
+
+      // Edit-mode state: the slug of the recipe currently being edited (null = add mode),
+      // plus an index of every recipe's data keyed by slug (loaded once from /recipes.json).
+      let editingSlug = null;
+      const recipesBySlug = {};
+      // True once the user has typed into the form since the last load/save; used to warn
+      // before the picker discards unsaved edits. Set only by real user input (not by the
+      // programmatic value-setting in fillForm/resetDynamic, which fire no 'input' event).
+      let formDirty = false;
+
+      const tpl = (id) => document.getElementById(id);
+      function addRow(listSel, tplId) {
+        const list = $(listSel);
+        const node = tpl(tplId).content.firstElementChild.cloneNode(true);
+        list.appendChild(node);
+        return node;
+      }
+      // Generic single-line row (tools / notes / ingredient items).
+      function makeRow(field, placeholder) {
+        const row = tpl('tpl-row').content.firstElementChild.cloneNode(true);
+        const input = row.querySelector('input');
+        input.dataset.field = field;
+        input.placeholder = placeholder;
+        return row;
+      }
+      // Single source of truth for the simple single-line row types (field name + placeholder),
+      // shared by add mode (click handler) and edit mode (fillForm/fillList) so they can't drift.
+      const SIMPLE_ROWS = {
+        tool: 'e.g. Rolling pin',
+        note: 'A tip or variation…',
+        item: 'e.g. 2 ¼ cup flour',
+      };
+      const makeSimpleRow = (field) => makeRow(field, SIMPLE_ROWS[field]);
+
+      function addItem(itemsList) {
+        const row = makeSimpleRow('item');
+        itemsList.appendChild(row);
+        return row;
+      }
+      function addGroup() {
+        const group = addRow('#ingredients-list', 'tpl-group');
+        addItem(group.querySelector('.items-list'));
+        return group;
+      }
+      // Build a picker <option>; shared by the initial index load and post-add registration.
+      function makeOption(slug, title) {
+        const opt = document.createElement('option');
+        opt.value = slug;
+        opt.textContent = title;
+        return opt;
+      }
+
+      // ---- Row add / remove (event delegation) ----------------------------
+      form.addEventListener('click', (e) => {
+        const btn = e.target.closest('button[data-action]');
+        if (!btn) return;
+        switch (btn.dataset.action) {
+          case 'add-tool': $('#tools-list').appendChild(makeSimpleRow('tool')); break;
+          case 'add-note': $('#notes-list').appendChild(makeSimpleRow('note')); break;
+          case 'add-step': addRow('#steps-list', 'tpl-step'); break;
+          case 'add-group': addGroup(); break;
+          case 'add-item': addItem(btn.closest('[data-unit="group"]').querySelector('.items-list')); break;
+          case 'remove': btn.closest('[data-unit]')?.remove(); refreshPreview(); break;
+        }
+      });
+      form.addEventListener('input', () => {
+        formDirty = true;
+        refreshPreview();
+      });
+
+      // ---- Session / auth -------------------------------------------------
+      const currentSession = () => localStorage.getItem(SESSION_KEY);
+      const clearSession = () => localStorage.removeItem(SESSION_KEY);
+
+      // On return from OAuth the Worker redirects to /upload#session=<id>. Pull it out of the
+      // fragment (fragments never hit a server or log), stash it, then scrub the URL.
+      function ingestSessionFromHash() {
+        const prefix = '#session=';
+        if (location.hash.startsWith(prefix)) {
+          const id = location.hash.slice(prefix.length);
+          if (id) localStorage.setItem(SESSION_KEY, id);
+          history.replaceState(null, '', location.pathname + location.search);
+        }
+      }
+
+      function renderAuthState() {
+        const signed = !!currentSession();
+        authState.textContent = signed ? '✓ Signed in with GitHub' : 'Not signed in';
+        authState.className =
+          'text-sm ' + (signed ? 'text-green-600 dark:text-green-500' : 'text-neutral-500 dark:text-neutral-400');
+        signinBtn.classList.toggle('hidden', signed);
+        signoutBtn.classList.toggle('hidden', !signed);
+      }
+
+      signoutBtn.addEventListener('click', async () => {
+        const session = currentSession();
+        if (session) {
+          // Best-effort server-side revoke; the local session is cleared regardless.
+          try {
+            await fetch(`${API}/logout`, { method: 'POST', headers: { Authorization: `Bearer ${session}` } });
+          } catch { /* offline is fine — we still drop the local id */ }
+        }
+        clearSession();
+        renderAuthState();
+        setStatus('Signed out.', 'ok');
+      });
+
+      // ---- Status ---------------------------------------------------------
+      // textContent (not innerHTML) — messages can include server-returned error text,
+      // which must never be parsed as markup. Callers that need a link append DOM nodes.
+      function setStatus(msg, kind = '') {
+        statusEl.textContent = msg;
+        statusEl.className =
+          'mt-2 text-sm ' +
+          (kind === 'ok' ? 'text-green-600 dark:text-green-500'
+            : kind === 'err' ? 'text-red-600 dark:text-red-400'
+            : 'text-neutral-500 dark:text-neutral-400');
+      }
+
+      // ---- Read form into a recipe object ---------------------------------
+      const val = (sel) => ($(sel)?.value ?? '').trim();
+      const listVals = (listSel, field) =>
+        Array.from($(listSel).querySelectorAll(`[data-field="${field}"]`))
+          .map((el) => el.value.trim())
+          .filter(Boolean);
+      const numOrUndef = (sel) => {
+        const v = val(sel);
+        if (v === '') return undefined;
+        const n = Number(v);
+        return Number.isFinite(n) ? n : undefined;
+      };
+
+      function readForm() {
+        const ingredients = [];
+        for (const groupEl of $('#ingredients-list').querySelectorAll('[data-unit="group"]')) {
+          const items = Array.from(groupEl.querySelectorAll('[data-field="item"]'))
+            .map((el) => el.value.trim())
+            .filter(Boolean);
+          if (items.length === 0) continue;
+          const name = (groupEl.querySelector('[data-field="group"]')?.value ?? '').trim();
+          ingredients.push(name ? { group: name, items } : { items });
+        }
+        return {
+          title: val('#title'),
+          category: val('#category'),
+          description: val('#description') || undefined,
+          keywords: val('#keywords').split(',').map((k) => k.trim()).filter(Boolean),
+          prepTime: numOrUndef('#prepTime'),
+          cookTime: numOrUndef('#cookTime'),
+          servings: numOrUndef('#servings'),
+          tools: listVals('#tools-list', 'tool'),
+          ingredients,
+          steps: listVals('#steps-list', 'step'),
+          notes: listVals('#notes-list', 'note'),
+          draft: $('#draft').checked,
+        };
+      }
+
+      // ---- YAML frontmatter serializer ------------------------------------
+      // Escape order matters: backslashes first, then the chars whose escapes
+      // introduce backslashes. Newlines/tabs must be escaped too — a raw newline
+      // inside a double-quoted YAML scalar is a "missing closing quote" parse error.
+      const q = (s) =>
+        '"' +
+        s
+          .replace(/\\/g, '\\\\')
+          .replace(/"/g, '\\"')
+          .replace(/\n/g, '\\n')
+          .replace(/\r/g, '\\r')
+          .replace(/\t/g, '\\t') +
+        '"';
+
+      function toMarkdown(r) {
+        const L = ['---'];
+        L.push(`title: ${q(r.title)}`);
+        L.push(`category: ${q(r.category)}`);
+        if (r.description) L.push(`description: ${q(r.description)}`);
+        if (r.keywords.length) L.push(`keywords: [${r.keywords.map(q).join(', ')}]`);
+        if (r.prepTime !== undefined) L.push(`prepTime: ${r.prepTime}`);
+        if (r.cookTime !== undefined) L.push(`cookTime: ${r.cookTime}`);
+        if (r.servings !== undefined) L.push(`servings: ${r.servings}`);
+        if (r.tools.length) {
+          L.push('tools:');
+          for (const t of r.tools) L.push(`  - ${q(t)}`);
+        }
+        L.push('ingredients:');
+        for (const g of r.ingredients) {
+          if (g.group) {
+            L.push(`  - group: ${q(g.group)}`);
+            L.push('    items:');
+          } else {
+            L.push('  - items:');
+          }
+          for (const it of g.items) L.push(`      - ${q(it)}`);
+        }
+        L.push('steps:');
+        for (const s of r.steps) L.push(`  - ${q(s)}`);
+        if (r.notes.length) {
+          L.push('notes:');
+          for (const n of r.notes) L.push(`  - ${q(n)}`);
+        }
+        if (r.draft) L.push('draft: true');
+        L.push('---');
+        return L.join('\n') + '\n';
+      }
+
+      function slugify(t) {
+        return t.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+      }
+
+      function validate(r) {
+        if (!r.title) return 'Add a title.';
+        if (!slugify(r.title)) return 'Title needs at least one letter or number.';
+        if (!r.category) return 'Pick a category.';
+        if (r.ingredients.length === 0) return 'Add at least one ingredient.';
+        if (r.steps.length === 0) return 'Add at least one step.';
+        // Mirror the schema's numeric constraints (int + nonnegative/positive) so a
+        // stray decimal or out-of-range value is caught here, not by a failed deploy build.
+        const numeric = [
+          ['Prep time', r.prepTime, 0],
+          ['Cook time', r.cookTime, 0],
+          ['Servings', r.servings, 1],
+        ];
+        for (const [name, v, min] of numeric) {
+          if (v !== undefined && (!Number.isInteger(v) || v < min)) {
+            return `${name} must be a whole number (${min} or more).`;
+          }
+        }
+        return null;
+      }
+
+      function refreshPreview() {
+        // Skip work while the preview panel is collapsed — it's refreshed on open (toggle).
+        if (!previewDetails.open) return;
+        try {
+          previewEl.textContent = toMarkdown(readForm());
+        } catch {
+          /* ignore mid-edit errors */
+        }
+      }
+      previewDetails.addEventListener('toggle', () => {
+        if (previewDetails.open) refreshPreview();
+      });
+
+      // ---- Recipe API (via the Worker) ------------------------------------
+      // All writes go through the Worker with the opaque session id as a bearer token; the
+      // Worker injects the real GitHub token server-side.
+      function apiFetch(path, options = {}) {
+        const session = currentSession();
+        return fetch(`${API}${path}`, {
+          ...options,
+          headers: { Authorization: `Bearer ${session}`, 'Content-Type': 'application/json', ...(options.headers || {}) },
+        });
+      }
+
+      // Extract a human message from a failed API response. A 401 means the session is gone —
+      // clear it and flip the UI back to signed-out so the fix (re-sign-in) is obvious.
+      async function apiError(res) {
+        let msg = '';
+        try { msg = (await res.json()).error ?? ''; } catch { /* noop */ }
+        if (res.status === 401) {
+          clearSession();
+          renderAuthState();
+          return msg || 'Session expired — sign in again.';
+        }
+        return msg || `Server error ${res.status}.`;
+      }
+
+      // ---- Copy markdown --------------------------------------------------
+      $('#copy-md').addEventListener('click', async () => {
+        try {
+          await navigator.clipboard.writeText(toMarkdown(readForm()));
+          setStatus('Markdown copied.', 'ok');
+        } catch {
+          setStatus('Could not copy — select the preview text manually.', 'err');
+        }
+      });
+
+      // ---- Submit ---------------------------------------------------------
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const recipe = readForm();
+        const problem = validate(recipe);
+        if (problem) { setStatus(problem, 'err'); return; }
+
+        if (!currentSession()) {
+          setStatus('Sign in with GitHub first (top of the page).', 'err');
+          return;
+        }
+
+        // In edit mode the file keeps its original slug even if the title changed, so the
+        // URL stays stable and no orphaned file is left behind. Add mode slugifies the title.
+        const slug = editingSlug ?? slugify(recipe.title);
+        const md = toMarkdown(recipe);
+
+        publishBtn.disabled = true;
+        deleteBtn.disabled = true;
+        try {
+          setStatus(editingSlug ? 'Saving…' : 'Publishing…', 'info');
+          const commit = (overwrite) =>
+            apiFetch('/api/recipe', {
+              method: 'POST',
+              body: JSON.stringify({
+                slug,
+                markdown: md,
+                message: `${overwrite ? 'Update' : 'Add'} recipe: ${recipe.title}`,
+                overwrite,
+              }),
+            });
+
+          // Edit mode always overwrites. Add mode tries create-only first; a 409 means a file
+          // already exists at that slug, so confirm and retry as an overwrite.
+          let res = await commit(!!editingSlug);
+          if (res.status === 409) {
+            if (!confirm(`A recipe already exists at "${slug}.md". Overwrite it?`)) {
+              setStatus('Cancelled — nothing published.', 'info');
+              return;
+            }
+            res = await commit(true);
+          }
+          if (!res.ok) throw new Error(await apiError(res));
+
+          const url = `${SITE_ORIGIN}/recipes/${slug}/`;
+          setStatus((editingSlug ? 'Saved! 🎉' : 'Published! 🎉') + " It'll be live in a minute or two at ", 'ok');
+          const link = document.createElement('a');
+          link.href = url;
+          link.textContent = url;
+          link.className = 'underline';
+          statusEl.appendChild(link);
+
+          if (editingSlug) {
+            // Stay in edit mode for easy further tweaks; keep the local index + picker label in sync.
+            recipesBySlug[editingSlug] = recipe;
+            const opt = picker.querySelector(`option[value="${editingSlug}"]`);
+            if (opt) opt.textContent = recipe.title;
+          } else {
+            // Register the freshly-created recipe so it's immediately pickable without a reload.
+            if (!recipesBySlug[slug]) picker.appendChild(makeOption(slug, recipe.title));
+            recipesBySlug[slug] = recipe;
+            form.reset();
+            resetDynamic();
+          }
+          formDirty = false;
+        } catch (err) {
+          setStatus(err instanceof Error ? err.message : 'Something went wrong.', 'err');
+        } finally {
+          publishBtn.disabled = false;
+          deleteBtn.disabled = false;
+        }
+      });
+
+      // ---- Delete ---------------------------------------------------------
+      deleteBtn.addEventListener('click', async () => {
+        if (!editingSlug) return;
+        if (!currentSession()) {
+          setStatus('Sign in with GitHub first (top of the page).', 'err');
+          return;
+        }
+        const slug = editingSlug;
+        const title = recipesBySlug[slug]?.title ?? slug;
+        if (!confirm(`Delete “${title}”? This removes ${slug}.md from the site.`)) return;
+
+        deleteBtn.disabled = true;
+        publishBtn.disabled = true;
+        try {
+          setStatus('Deleting…', 'info');
+          const res = await apiFetch('/api/recipe', {
+            method: 'DELETE',
+            body: JSON.stringify({ slug, message: `Delete recipe: ${title}` }),
+          });
+          if (res.status === 404) {
+            setStatus('That recipe no longer exists on the server.', 'err');
+            return;
+          }
+          if (!res.ok) throw new Error(await apiError(res));
+
+          // Drop it from the local index + picker, then fall back to a blank add form.
+          delete recipesBySlug[slug];
+          picker.querySelector(`option[value="${slug}"]`)?.remove();
+          enterAddMode();
+          setStatus(`Deleted “${title}”. The site will update in a minute or two.`, 'ok');
+        } catch (err) {
+          setStatus(err instanceof Error ? err.message : 'Something went wrong.', 'err');
+        } finally {
+          deleteBtn.disabled = false;
+          publishBtn.disabled = false;
+        }
+      });
+
+      // ---- Edit mode: load existing recipes & prefill ---------------------
+      async function loadRecipeIndex() {
+        try {
+          const res = await fetch('/recipes.json', { headers: { Accept: 'application/json' } });
+          if (!res.ok) return;
+          const list = await res.json();
+          const frag = document.createDocumentFragment();
+          for (const r of list) {
+            recipesBySlug[r.slug] = r;
+            frag.appendChild(makeOption(r.slug, r.title));
+          }
+          picker.appendChild(frag);
+          // Deep link: /upload?edit=<slug> jumps straight into editing once data is in.
+          const wanted = new URLSearchParams(location.search).get('edit');
+          if (wanted && recipesBySlug[wanted]) enterEditMode(wanted);
+        } catch {
+          /* the picker is a convenience — a failed index just leaves add mode intact */
+        }
+      }
+
+      function setRowValue(row, field, value) {
+        row.querySelector(`[data-field="${field}"]`).value = value;
+      }
+
+      // Clear a list container and repopulate it with one simple row per value.
+      function fillList(listSel, field, values) {
+        const list = $(listSel);
+        list.innerHTML = '';
+        for (const v of values ?? []) {
+          const row = makeSimpleRow(field);
+          row.querySelector('input').value = v;
+          list.appendChild(row);
+        }
+      }
+
+      function fillForm(r) {
+        const setVal = (sel, v) => {
+          const el = $(sel);
+          if (el) el.value = v === undefined || v === null ? '' : String(v);
+        };
+        setVal('#title', r.title);
+        $('#category').value = r.category;
+        setVal('#description', r.description);
+        setVal('#keywords', (r.keywords ?? []).join(', '));
+        setVal('#prepTime', r.prepTime);
+        setVal('#cookTime', r.cookTime);
+        setVal('#servings', r.servings);
+        $('#draft').checked = !!r.draft;
+
+        // Rebuild the dynamic lists from data, reusing the same row builders as add mode.
+        fillList('#tools-list', 'tool', r.tools);
+        fillList('#notes-list', 'note', r.notes);
+
+        $('#steps-list').innerHTML = '';
+        for (const s of r.steps ?? []) {
+          const row = addRow('#steps-list', 'tpl-step');
+          setRowValue(row, 'step', s);
+        }
+
+        $('#ingredients-list').innerHTML = '';
+        const groups = r.ingredients ?? [];
+        if (groups.length === 0) addGroup();
+        for (const g of groups) {
+          const groupEl = addRow('#ingredients-list', 'tpl-group');
+          if (g.group) setRowValue(groupEl, 'group', g.group);
+          const itemsList = groupEl.querySelector('.items-list');
+          const items = g.items ?? [];
+          if (items.length === 0) addItem(itemsList);
+          for (const it of items) addItem(itemsList).querySelector('input').value = it;
+        }
+      }
+
+      function enterEditMode(slug) {
+        const r = recipesBySlug[slug];
+        if (!r) return;
+        editingSlug = slug;
+        picker.value = slug;
+        fillForm(r);
+        pageTitle.textContent = 'Edit recipe';
+        pageIntro.textContent = 'Tweak it, save, and the change goes live in a minute or two.';
+        publishBtn.textContent = 'Save changes';
+        deleteBtn.classList.remove('hidden');
+        refreshPreview();
+        setStatus(`Editing “${r.title}”.`, 'info');
+        formDirty = false;
+      }
+
+      function enterAddMode() {
+        editingSlug = null;
+        picker.value = '';
+        pageTitle.textContent = 'Add a recipe';
+        pageIntro.textContent = 'Fill it in, hit publish, and it goes live in a minute or two.';
+        publishBtn.textContent = 'Publish 🚀';
+        deleteBtn.classList.add('hidden');
+        form.reset();
+        resetDynamic();
+        setStatus('', '');
+        formDirty = false;
+      }
+
+      picker.addEventListener('change', () => {
+        const slug = picker.value;
+        const current = editingSlug ?? '';
+        if (slug === current) return;
+        // Guard against silently wiping in-progress edits when switching recipes.
+        if (formDirty && !confirm('Discard unsaved changes to this recipe?')) {
+          picker.value = current;
+          return;
+        }
+        if (slug && recipesBySlug[slug]) enterEditMode(slug);
+        else enterAddMode();
+      });
+
+      // ---- Init -----------------------------------------------------------
+      function resetDynamic() {
+        $('#tools-list').innerHTML = '';
+        $('#notes-list').innerHTML = '';
+        $('#ingredients-list').innerHTML = '';
+        $('#steps-list').innerHTML = '';
+        addGroup();
+        addRow('#steps-list', 'tpl-step');
+        refreshPreview();
+      }
+      ingestSessionFromHash();
+      renderAuthState();
+      resetDynamic();
+      loadRecipeIndex();
+    </script>
+  </body>
+</html>

--- a/src/pages/upload.astro
+++ b/src/pages/upload.astro
@@ -280,6 +280,17 @@ const removeBtn =
         return opt;
       }
 
+      // Reconcile the in-memory index + picker with a just-saved recipe so the UI matches what a
+      // reload would show. Drafts are excluded from /recipes.json, so they're kept out of the
+      // picker (a saved draft would otherwise appear, then vanish on the next load).
+      function syncPickerEntry(slug, recipe) {
+        recipesBySlug[slug] = recipe;
+        const opt = picker.querySelector(`option[value="${slug}"]`);
+        if (recipe.draft) opt?.remove();
+        else if (opt) opt.textContent = recipe.title;
+        else picker.appendChild(makeOption(slug, recipe.title));
+      }
+
       // ---- Row add / remove (event delegation) ----------------------------
       form.addEventListener('click', (e) => {
         const btn = e.target.closest('button[data-action]');
@@ -550,23 +561,27 @@ const removeBtn =
           }
           if (!res.ok) throw new Error(await apiError(res));
 
-          const url = `${SITE_ORIGIN}/recipes/${slug}/`;
-          setStatus((editingSlug ? 'Saved! 🎉' : 'Published! 🎉') + " It'll be live in a minute or two at ", 'ok');
-          const link = document.createElement('a');
-          link.href = url;
-          link.textContent = url;
-          link.className = 'underline';
-          statusEl.appendChild(link);
+          // Keep the picker + index in sync with the save (drops drafts from the picker).
+          syncPickerEntry(slug, recipe);
 
-          if (editingSlug) {
-            // Stay in edit mode for easy further tweaks; keep the local index + picker label in sync.
-            recipesBySlug[editingSlug] = recipe;
-            const opt = picker.querySelector(`option[value="${editingSlug}"]`);
-            if (opt) opt.textContent = recipe.title;
+          if (recipe.draft) {
+            // A draft has no detail page, so don't dangle a "live at…" link it can't fulfill.
+            setStatus(
+              (editingSlug ? 'Saved' : 'Created') +
+                ' as a draft 📝 — hidden from the site and the picker until you un-draft it in the repo.',
+              'ok'
+            );
           } else {
-            // Register the freshly-created recipe so it's immediately pickable without a reload.
-            if (!recipesBySlug[slug]) picker.appendChild(makeOption(slug, recipe.title));
-            recipesBySlug[slug] = recipe;
+            setStatus((editingSlug ? 'Saved! 🎉' : 'Published! 🎉') + " It'll be live in a minute or two at ", 'ok');
+            const link = document.createElement('a');
+            link.href = `${SITE_ORIGIN}/recipes/${slug}/`;
+            link.textContent = link.href;
+            link.className = 'underline';
+            statusEl.appendChild(link);
+          }
+
+          // Add mode: clear the form for the next recipe. Edit mode: stay put for further tweaks.
+          if (!editingSlug) {
             form.reset();
             resetDynamic();
           }

--- a/worker/.dev.vars.example
+++ b/worker/.dev.vars.example
@@ -1,0 +1,3 @@
+# Copy to `.dev.vars` for `wrangler dev` (git-ignored). In production these come from
+# `wrangler secret put` (the secret) and [vars] in wrangler.toml (the rest).
+GITHUB_CLIENT_SECRET="your-oauth-app-client-secret"

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,0 +1,60 @@
+# Recipe API Worker
+
+Cloudflare Worker that powers "Sign in with GitHub" on `izzybennett.com/upload`. It runs the
+OAuth handshake (holding the client secret) and proxies every recipe create/update/delete so the
+**GitHub token never reaches the browser** — the browser only holds an opaque session id.
+
+## One-time setup
+
+1. **Register a GitHub OAuth App** — GitHub → Settings → Developer settings → **OAuth Apps** → New:
+   - Application name: `Izzy recipe uploader` (anything)
+   - Homepage URL: `https://izzybennett.com`
+   - **Authorization callback URL:** `https://<your-worker-url>/callback`
+     (e.g. `https://izzy-recipe-api.<subdomain>.workers.dev/callback`)
+   - Generate a client secret. Note the **Client ID** and **Client Secret**.
+
+2. **Create the KV namespace** and copy the ids into `wrangler.toml`:
+   ```sh
+   npx wrangler kv namespace create SESSIONS
+   npx wrangler kv namespace create SESSIONS --preview
+   ```
+
+3. **Fill in `wrangler.toml`** — `GITHUB_CLIENT_ID`, the KV `id`/`preview_id`, and (if different)
+   `ALLOWED_LOGIN`, `SITE_ORIGIN`.
+
+4. **Set the secret:**
+   ```sh
+   npx wrangler secret put GITHUB_CLIENT_SECRET
+   ```
+
+5. **Deploy:**
+   ```sh
+   npm install
+   npm run deploy
+   ```
+
+6. Point the site at the Worker: set `PUBLIC_RECIPE_API` to the Worker's base URL when building the
+   Astro site (see the repo root README / `deploy.yml`).
+
+## Local dev
+
+```sh
+cp .dev.vars.example .dev.vars   # add your client secret
+npm install
+npm run dev
+```
+
+For local testing, register a second OAuth App (or edit the existing one) whose callback points at
+`http://localhost:8787/callback`, and set `SITE_ORIGIN` to your local site origin.
+
+## Endpoints
+
+| Method + path        | Auth                    | Purpose                                  |
+| -------------------- | ----------------------- | ---------------------------------------- |
+| `GET /login`         | —                       | Redirect to GitHub consent               |
+| `GET /callback`      | state cookie            | Exchange code, gate on `ALLOWED_LOGIN`, mint session |
+| `POST /api/recipe`   | `Bearer <session>`      | Create/update `RECIPE_DIR/<slug>.md` (409 if exists and `overwrite` false) |
+| `DELETE /api/recipe` | `Bearer <session>`      | Delete a recipe file                     |
+| `POST /logout`       | `Bearer <session>`      | Destroy the session                      |
+
+Every proxied path is hard-restricted to `RECIPE_DIR/<slug>.md` on `OWNER/REPO@BRANCH`.

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,0 +1,1642 @@
+{
+  "name": "izzy-recipe-api",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "izzy-recipe-api",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20241106.0",
+        "typescript": "^5.6.0",
+        "wrangler": "^3.90.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
+      "integrity": "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.0.2.tgz",
+      "integrity": "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.14",
+        "workerd": "^1.20250124.0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250718.0.tgz",
+      "integrity": "sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250718.0.tgz",
+      "integrity": "sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250718.0.tgz",
+      "integrity": "sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250718.0.tgz",
+      "integrity": "sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250718.0.tgz",
+      "integrity": "sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260702.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-globals-polyfill": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
+      "integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
+      "integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/as-table": {
+      "version": "1.0.55",
+      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
+      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "printable-characters": "^1.0.42"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
+      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/exit-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+      "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-source": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
+      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "data-uri-to-buffer": "^2.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "3.20250718.3",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250718.3.tgz",
+      "integrity": "sha512-JuPrDJhwLrNLEJiNLWO7ZzJrv/Vv9kZuwMYCfv0LskQDM6Eonw4OvywO3CH/wCGjgHzha/qyjUh8JQ068TjDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "8.14.0",
+        "acorn-walk": "8.3.2",
+        "exit-hook": "2.2.1",
+        "glob-to-regexp": "0.4.1",
+        "stoppable": "1.1.0",
+        "undici": "^5.28.5",
+        "workerd": "1.20250718.0",
+        "ws": "8.18.0",
+        "youch": "3.3.4",
+        "zod": "3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/printable-characters": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
+      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "node_modules/rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stacktracey": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
+      "integrity": "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "as-table": "^1.0.36",
+        "get-source": "^2.0.12"
+      }
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
+      "integrity": "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "exsolve": "^1.0.1",
+        "ohash": "^2.0.10",
+        "pathe": "^2.0.3",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250718.0.tgz",
+      "integrity": "sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20250718.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20250718.0",
+        "@cloudflare/workerd-linux-64": "1.20250718.0",
+        "@cloudflare/workerd-linux-arm64": "1.20250718.0",
+        "@cloudflare/workerd-windows-64": "1.20250718.0"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "3.114.17",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.17.tgz",
+      "integrity": "sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.3.4",
+        "@cloudflare/unenv-preset": "2.0.2",
+        "@esbuild-plugins/node-globals-polyfill": "0.2.3",
+        "@esbuild-plugins/node-modules-polyfill": "0.2.2",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.17.19",
+        "miniflare": "3.20250718.3",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.14",
+        "workerd": "1.20250718.0"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2",
+        "sharp": "^0.33.5"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20250408.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
+      "integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.7.1",
+        "mustache": "^4.2.0",
+        "stacktracey": "^2.1.8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "izzy-recipe-api",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Cloudflare Worker: GitHub OAuth backend + recipe write proxy for izzybennett.com/upload",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "tail": "wrangler tail"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20241106.0",
+    "typescript": "^5.6.0",
+    "wrangler": "^3.90.0"
+  }
+}

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -1,0 +1,322 @@
+/**
+ * Recipe API — Cloudflare Worker that turns the pasted-PAT flow on /upload into a proper
+ * "Sign in with GitHub" OAuth flow, WITHOUT ever handing a GitHub token to the browser.
+ *
+ * Flow:
+ *   GET  /login        → 302 to GitHub's OAuth consent screen (state stored in a cookie)
+ *   GET  /callback     → exchange code→token (uses the client secret), verify the user is
+ *                        ALLOWED_LOGIN, mint an opaque session id, stash {token,login} in KV,
+ *                        then 302 back to the site with the session id in the URL fragment.
+ *   POST   /api/recipe → create/update a recipe file (auth: `Authorization: Bearer <session>`)
+ *   DELETE /api/recipe → delete a recipe file
+ *   POST   /logout     → destroy the session
+ *
+ * The browser only ever holds the opaque session id. The GitHub token lives in KV and is
+ * injected server-side here, and every proxied call is hard-restricted to RECIPE_DIR/<slug>.md
+ * on OWNER/REPO@BRANCH — so a leaked session can only ever touch recipe files.
+ */
+
+export interface Env {
+  SESSIONS: KVNamespace;
+  // Secret (wrangler secret put):
+  GITHUB_CLIENT_SECRET: string;
+  // Vars (wrangler.toml [vars]):
+  GITHUB_CLIENT_ID: string;
+  ALLOWED_LOGIN: string;
+  OWNER: string;
+  REPO: string;
+  BRANCH: string;
+  RECIPE_DIR: string;
+  SITE_ORIGIN: string;
+  SESSION_TTL: string;
+}
+
+interface Session {
+  token: string;
+}
+
+const GH_API = 'https://api.github.com';
+const GH_OAUTH = 'https://github.com/login/oauth';
+const UA = 'izzy-recipe-worker';
+const SLUG_RE = /^[a-z0-9-]+$/;
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    // CORS preflight for the browser-facing API endpoints.
+    if (request.method === 'OPTIONS') return preflight(env);
+
+    try {
+      switch (`${request.method} ${url.pathname}`) {
+        case 'GET /login':
+          return handleLogin(url, env);
+        case 'GET /callback':
+          return handleCallback(request, url, env);
+        case 'POST /api/recipe':
+          return withSession(request, env, (_id, s) => putRecipe(request, env, s));
+        case 'DELETE /api/recipe':
+          return withSession(request, env, (_id, s) => deleteRecipe(request, env, s));
+        case 'POST /logout':
+          return withSession(request, env, (id) => logout(env, id));
+        case 'GET /':
+          return json(env, 200, { ok: true, service: 'izzy-recipe-api' });
+        default:
+          return json(env, 404, { error: 'Not found' });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unexpected error';
+      return json(env, 500, { error: message });
+    }
+  },
+};
+
+// ---- OAuth: login ---------------------------------------------------------
+
+function handleLogin(url: URL, env: Env): Response {
+  const state = crypto.randomUUID();
+  const authorize = new URL(`${GH_OAUTH}/authorize`);
+  authorize.searchParams.set('client_id', env.GITHUB_CLIENT_ID);
+  authorize.searchParams.set('redirect_uri', `${url.origin}/callback`);
+  authorize.searchParams.set('scope', 'public_repo'); // least privilege that allows Contents writes
+  authorize.searchParams.set('state', state);
+  authorize.searchParams.set('allow_signup', 'false');
+
+  // Stash the state in a short-lived, first-party (worker-origin) cookie to check on callback.
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: authorize.toString(),
+      'Set-Cookie': `oauth_state=${state}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=600`,
+    },
+  });
+}
+
+// ---- OAuth: callback ------------------------------------------------------
+
+async function handleCallback(request: Request, url: URL, env: Env): Promise<Response> {
+  const code = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+  const cookieState = readCookie(request, 'oauth_state');
+
+  if (!code || !state || !cookieState || state !== cookieState) {
+    return htmlError('Sign-in failed: invalid or expired state. Please try again.');
+  }
+
+  // Exchange the code for a token — the only place the client secret is used.
+  const tokenRes = await fetch(`${GH_OAUTH}/access_token`, {
+    method: 'POST',
+    headers: { Accept: 'application/json', 'Content-Type': 'application/json', 'User-Agent': UA },
+    body: JSON.stringify({
+      client_id: env.GITHUB_CLIENT_ID,
+      client_secret: env.GITHUB_CLIENT_SECRET,
+      code,
+      redirect_uri: `${url.origin}/callback`,
+    }),
+  });
+  const tokenData = (await tokenRes.json()) as { access_token?: string; error?: string };
+  const token = tokenData.access_token;
+  if (!token) {
+    return htmlError(`Sign-in failed: ${tokenData.error ?? 'no token returned'}.`);
+  }
+
+  // Identify the user and gate on the allowlist — the OAuth App is public, so anyone could
+  // authorize it; only ALLOWED_LOGIN may ever get a session that can write to the repo.
+  const userRes = await fetch(`${GH_API}/user`, {
+    headers: { Authorization: `Bearer ${token}`, Accept: 'application/vnd.github+json', 'User-Agent': UA },
+  });
+  const user = (await userRes.json()) as { login?: string };
+  if (!user.login || user.login.toLowerCase() !== env.ALLOWED_LOGIN.toLowerCase()) {
+    return htmlError(`Sorry, @${user.login ?? 'unknown'} is not allowed to edit recipes.`);
+  }
+
+  // Mint an opaque session id; the GitHub token stays server-side in KV.
+  const sessionId = crypto.randomUUID();
+  const ttl = Number(env.SESSION_TTL) || 28800;
+  const session: Session = { token };
+  await env.SESSIONS.put(sessionId, JSON.stringify(session), { expirationTtl: ttl });
+
+  // Hand the session id back via the URL fragment — fragments aren't sent to servers or logged.
+  // Also clear the state cookie.
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: `${env.SITE_ORIGIN}/upload#session=${sessionId}`,
+      'Set-Cookie': 'oauth_state=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0',
+    },
+  });
+}
+
+// ---- Session auth wrapper -------------------------------------------------
+
+async function withSession(
+  request: Request,
+  env: Env,
+  handler: (sessionId: string, session: Session) => Promise<Response>
+): Promise<Response> {
+  const auth = request.headers.get('Authorization') ?? '';
+  const sessionId = auth.startsWith('Bearer ') ? auth.slice(7) : '';
+  if (!sessionId) return json(env, 401, { error: 'Not signed in.' });
+
+  const raw = await env.SESSIONS.get(sessionId);
+  if (!raw) return json(env, 401, { error: 'Session expired. Please sign in again.' });
+
+  return handler(sessionId, JSON.parse(raw) as Session);
+}
+
+async function logout(env: Env, sessionId: string): Promise<Response> {
+  await env.SESSIONS.delete(sessionId);
+  return json(env, 200, { ok: true });
+}
+
+// ---- Recipe proxy (create / update / delete) ------------------------------
+
+// Resolve + validate the target path for a slug. Rejects anything that isn't a plain recipe
+// slug, so a crafted request can never reach a file outside RECIPE_DIR.
+function recipePath(env: Env, slug: unknown): string | null {
+  if (typeof slug !== 'string' || !SLUG_RE.test(slug)) return null;
+  return `${env.RECIPE_DIR}/${slug}.md`;
+}
+
+function contentsUrl(env: Env, path: string): string {
+  return `${GH_API}/repos/${env.OWNER}/${env.REPO}/contents/${path}`;
+}
+
+function ghHeaders(token: string) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': UA,
+  };
+}
+
+async function getSha(env: Env, token: string, path: string): Promise<string | null> {
+  const res = await fetch(`${contentsUrl(env, path)}?ref=${env.BRANCH}`, { headers: ghHeaders(token) });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`GitHub error ${res.status} while reading existing file.`);
+  const data = (await res.json()) as { sha: string };
+  return data.sha;
+}
+
+// Send a create/update/delete to the GitHub Contents API. Returns null on success, or a ready-to-
+// send 502 Response if GitHub rejected it — both mutation routes share this uniform translation.
+async function commit(
+  env: Env,
+  token: string,
+  method: 'PUT' | 'DELETE',
+  path: string,
+  payload: Record<string, unknown>,
+  action: string
+): Promise<Response | null> {
+  const res = await fetch(contentsUrl(env, path), {
+    method,
+    headers: { ...ghHeaders(token), 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const detail = await res.text();
+    return json(env, 502, { error: `GitHub rejected the ${action} (${res.status}).`, detail });
+  }
+  return null;
+}
+
+// UTF-8 safe base64 for the file content GitHub's Contents API expects.
+function b64(str: string): string {
+  const bytes = new TextEncoder().encode(str);
+  let bin = '';
+  for (const byte of bytes) bin += String.fromCharCode(byte);
+  return btoa(bin);
+}
+
+async function putRecipe(request: Request, env: Env, session: Session): Promise<Response> {
+  const body = (await request.json()) as {
+    slug?: string;
+    markdown?: string;
+    message?: string;
+    overwrite?: boolean;
+  };
+  const path = recipePath(env, body.slug);
+  if (!path) return json(env, 400, { error: 'Invalid recipe slug.' });
+  if (typeof body.markdown !== 'string' || !body.markdown) {
+    return json(env, 400, { error: 'Missing recipe content.' });
+  }
+
+  const sha = await getSha(env, session.token, path);
+  // Guard against silently clobbering an existing recipe in add mode; edit mode passes overwrite.
+  if (sha && !body.overwrite) {
+    return json(env, 409, { error: 'A recipe already exists at that slug.', exists: true });
+  }
+
+  const payload: Record<string, unknown> = {
+    message: body.message || `${sha ? 'Update' : 'Add'} recipe: ${body.slug}`,
+    content: b64(body.markdown),
+    branch: env.BRANCH,
+  };
+  if (sha) payload.sha = sha;
+
+  const err = await commit(env, session.token, 'PUT', path, payload, 'commit');
+  if (err) return err;
+  return json(env, 200, { ok: true, created: !sha });
+}
+
+async function deleteRecipe(request: Request, env: Env, session: Session): Promise<Response> {
+  const body = (await request.json()) as { slug?: string; message?: string };
+  const path = recipePath(env, body.slug);
+  if (!path) return json(env, 400, { error: 'Invalid recipe slug.' });
+
+  const sha = await getSha(env, session.token, path);
+  if (!sha) return json(env, 404, { error: 'That recipe no longer exists.' });
+
+  const err = await commit(env, session.token, 'DELETE', path, {
+    message: body.message || `Delete recipe: ${body.slug}`,
+    sha,
+    branch: env.BRANCH,
+  }, 'delete');
+  if (err) return err;
+  return json(env, 200, { ok: true });
+}
+
+// ---- Small helpers --------------------------------------------------------
+
+function corsHeaders(env: Env): Record<string, string> {
+  return {
+    'Access-Control-Allow-Origin': env.SITE_ORIGIN,
+    'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+    'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+    'Access-Control-Max-Age': '86400',
+    Vary: 'Origin',
+  };
+}
+
+function preflight(env: Env): Response {
+  return new Response(null, { status: 204, headers: corsHeaders(env) });
+}
+
+function json(env: Env, status: number, data: unknown): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...corsHeaders(env) },
+  });
+}
+
+// Minimal HTML page for OAuth redirect errors (the browser lands here directly, not via fetch).
+function htmlError(message: string): Response {
+  const safe = message.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return new Response(
+    `<!doctype html><meta charset="utf-8"><title>Sign-in error</title>` +
+      `<body style="font-family:system-ui;max-width:32rem;margin:4rem auto;padding:0 1rem">` +
+      `<h1>Sign-in error</h1><p>${safe}</p><p><a href="/login">Try again</a></p></body>`,
+    { status: 400, headers: { 'Content-Type': 'text/html; charset=utf-8' } }
+  );
+}
+
+function readCookie(request: Request, name: string): string | null {
+  const header = request.headers.get('Cookie');
+  if (!header) return null;
+  for (const part of header.split(';')) {
+    const [k, ...v] = part.trim().split('=');
+    if (k === name) return v.join('=');
+  }
+  return null;
+}

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -40,6 +40,16 @@ const GH_OAUTH = 'https://github.com/login/oauth';
 const UA = 'izzy-recipe-worker';
 const SLUG_RE = /^[a-z0-9-]+$/;
 
+// Top-level frontmatter keys the /upload form owns and re-serializes on every save. Any OTHER
+// key found in an existing recipe (e.g. `image`) is NOT modelled by the form, so on update we
+// carry it over from the old file — otherwise editing a recipe through /upload would silently
+// drop it. Note: keys the form DOES manage but omits when empty (draft, description, …) are
+// deliberately absent here, so clearing them still works.
+const MANAGED_FIELDS = new Set([
+  'title', 'description', 'category', 'keywords', 'prepTime', 'cookTime',
+  'servings', 'tools', 'ingredients', 'steps', 'notes', 'draft',
+]);
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
@@ -191,12 +201,18 @@ function ghHeaders(token: string) {
   };
 }
 
-async function getSha(env: Env, token: string, path: string): Promise<string | null> {
+// Fetch the existing file's sha AND its decoded markdown (the Contents API returns both in one
+// GET, so this costs no extra round-trip). Returns null if the file doesn't exist yet.
+async function getExisting(
+  env: Env,
+  token: string,
+  path: string
+): Promise<{ sha: string; content: string } | null> {
   const res = await fetch(`${contentsUrl(env, path)}?ref=${env.BRANCH}`, { headers: ghHeaders(token) });
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`GitHub error ${res.status} while reading existing file.`);
-  const data = (await res.json()) as { sha: string };
-  return data.sha;
+  const data = (await res.json()) as { sha: string; content?: string };
+  return { sha: data.sha, content: data.content ? unb64(data.content) : '' };
 }
 
 // Send a create/update/delete to the GitHub Contents API. Returns null on success, or a ready-to-
@@ -229,6 +245,50 @@ function b64(str: string): string {
   return btoa(bin);
 }
 
+// Inverse of b64 — GitHub returns file content as base64 with embedded newlines.
+function unb64(b64str: string): string {
+  const bin = atob(b64str.replace(/\n/g, ''));
+  const bytes = Uint8Array.from(bin, (c) => c.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+// Split a top-level frontmatter block into ordered { key, lines } entries. A key line starts a
+// new entry; indented / list continuation lines belong to the entry above them.
+function frontmatterEntries(fm: string): Array<{ key: string; lines: string[] }> {
+  const entries: Array<{ key: string; lines: string[] }> = [];
+  let cur: { key: string; lines: string[] } | null = null;
+  for (const line of fm.split('\n')) {
+    const m = line.match(/^([A-Za-z0-9_]+):/);
+    if (m) {
+      cur = { key: m[1], lines: [line] };
+      entries.push(cur);
+    } else if (cur) {
+      cur.lines.push(line);
+    }
+  }
+  return entries;
+}
+
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n?/;
+
+// Carry any unmodelled top-level frontmatter (e.g. `image`) from the old file into the freshly
+// generated markdown, so editing through /upload never drops fields the form doesn't render.
+function preserveUnmanaged(oldMarkdown: string, newMarkdown: string): string {
+  const oldFm = oldMarkdown.match(FRONTMATTER_RE);
+  const newFm = newMarkdown.match(FRONTMATTER_RE);
+  if (!oldFm || !newFm) return newMarkdown;
+
+  const newKeys = new Set(frontmatterEntries(newFm[1]).map((e) => e.key));
+  const carried = frontmatterEntries(oldFm[1])
+    .filter((e) => !MANAGED_FIELDS.has(e.key) && !newKeys.has(e.key))
+    .flatMap((e) => e.lines);
+  if (carried.length === 0) return newMarkdown;
+
+  const merged = `---\n${newFm[1]}\n${carried.join('\n')}\n---\n`;
+  // Function replacement so `$` in preserved values isn't treated as a capture reference.
+  return newMarkdown.replace(FRONTMATTER_RE, () => merged);
+}
+
 async function putRecipe(request: Request, env: Env, session: Session): Promise<Response> {
   const body = (await request.json()) as {
     slug?: string;
@@ -242,22 +302,24 @@ async function putRecipe(request: Request, env: Env, session: Session): Promise<
     return json(env, 400, { error: 'Missing recipe content.' });
   }
 
-  const sha = await getSha(env, session.token, path);
+  const existing = await getExisting(env, session.token, path);
   // Guard against silently clobbering an existing recipe in add mode; edit mode passes overwrite.
-  if (sha && !body.overwrite) {
+  if (existing && !body.overwrite) {
     return json(env, 409, { error: 'A recipe already exists at that slug.', exists: true });
   }
 
+  // On update, re-attach any frontmatter the form doesn't model (e.g. `image`) from the old file.
+  const markdown = existing ? preserveUnmanaged(existing.content, body.markdown) : body.markdown;
   const payload: Record<string, unknown> = {
-    message: body.message || `${sha ? 'Update' : 'Add'} recipe: ${body.slug}`,
-    content: b64(body.markdown),
+    message: body.message || `${existing ? 'Update' : 'Add'} recipe: ${body.slug}`,
+    content: b64(markdown),
     branch: env.BRANCH,
   };
-  if (sha) payload.sha = sha;
+  if (existing) payload.sha = existing.sha;
 
   const err = await commit(env, session.token, 'PUT', path, payload, 'commit');
   if (err) return err;
-  return json(env, 200, { ok: true, created: !sha });
+  return json(env, 200, { ok: true, created: !existing });
 }
 
 async function deleteRecipe(request: Request, env: Env, session: Session): Promise<Response> {
@@ -265,12 +327,12 @@ async function deleteRecipe(request: Request, env: Env, session: Session): Promi
   const path = recipePath(env, body.slug);
   if (!path) return json(env, 400, { error: 'Invalid recipe slug.' });
 
-  const sha = await getSha(env, session.token, path);
-  if (!sha) return json(env, 404, { error: 'That recipe no longer exists.' });
+  const existing = await getExisting(env, session.token, path);
+  if (!existing) return json(env, 404, { error: 'That recipe no longer exists.' });
 
   const err = await commit(env, session.token, 'DELETE', path, {
     message: body.message || `Delete recipe: ${body.slug}`,
-    sha,
+    sha: existing.sha,
     branch: env.BRANCH,
   }, 'delete');
   if (err) return err;

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -58,28 +58,45 @@ export default {
     if (request.method === 'OPTIONS') return preflight(env);
 
     try {
+      // `await` matters: it lets this try/catch catch async rejections, so a thrown ApiError
+      // becomes a proper JSON response WITH CORS headers (a bare throw would yield Cloudflare's
+      // headerless 500, which the browser can't even read across origins).
       switch (`${request.method} ${url.pathname}`) {
         case 'GET /login':
           return handleLogin(url, env);
         case 'GET /callback':
-          return handleCallback(request, url, env);
+          // A browser navigation lands here, so surface failures as the friendly HTML page.
+          return await handleCallback(request, url, env).catch(() =>
+            htmlError('Something went wrong during sign-in. Please try again.')
+          );
         case 'POST /api/recipe':
-          return withSession(request, env, (_id, s) => putRecipe(request, env, s));
+          return await withSession(request, env, (_id, s) => putRecipe(request, env, s));
         case 'DELETE /api/recipe':
-          return withSession(request, env, (_id, s) => deleteRecipe(request, env, s));
+          return await withSession(request, env, (_id, s) => deleteRecipe(request, env, s));
         case 'POST /logout':
-          return withSession(request, env, (id) => logout(env, id));
+          return await withSession(request, env, (id) => logout(env, id));
         case 'GET /':
           return json(env, 200, { ok: true, service: 'izzy-recipe-api' });
         default:
           return json(env, 404, { error: 'Not found' });
       }
     } catch (err) {
+      if (err instanceof ApiError) return json(env, err.status, { error: err.message });
       const message = err instanceof Error ? err.message : 'Unexpected error';
       return json(env, 500, { error: message });
     }
   },
 };
+
+// Thrown by helpers to signal a specific HTTP status to the client, instead of a generic 500.
+class ApiError extends Error {
+  constructor(
+    readonly status: number,
+    message: string
+  ) {
+    super(message);
+  }
+}
 
 // ---- OAuth: login ---------------------------------------------------------
 
@@ -137,7 +154,7 @@ async function handleCallback(request: Request, url: URL, env: Env): Promise<Res
   });
   const user = (await userRes.json()) as { login?: string };
   if (!user.login || user.login.toLowerCase() !== env.ALLOWED_LOGIN.toLowerCase()) {
-    return htmlError(`Sorry, @${user.login ?? 'unknown'} is not allowed to edit recipes.`);
+    return htmlError(`Sorry, @${user.login ?? 'unknown'} is not allowed to edit recipes.`, 403);
   }
 
   // Mint an opaque session id; the GitHub token stays server-side in KV.
@@ -210,13 +227,15 @@ async function getExisting(
 ): Promise<{ sha: string; content: string } | null> {
   const res = await fetch(`${contentsUrl(env, path)}?ref=${env.BRANCH}`, { headers: ghHeaders(token) });
   if (res.status === 404) return null;
-  if (!res.ok) throw new Error(`GitHub error ${res.status} while reading existing file.`);
+  if (res.status === 401) throw new ApiError(401, 'Your GitHub sign-in expired. Please sign in again.');
+  if (!res.ok) throw new ApiError(502, `GitHub error ${res.status} while reading the recipe.`);
   const data = (await res.json()) as { sha: string; content?: string };
   return { sha: data.sha, content: data.content ? unb64(data.content) : '' };
 }
 
-// Send a create/update/delete to the GitHub Contents API. Returns null on success, or a ready-to-
-// send 502 Response if GitHub rejected it — both mutation routes share this uniform translation.
+// Send a create/update/delete to the GitHub Contents API. Resolves on success; throws an
+// ApiError otherwise — 401 (dead token) is surfaced as-is so the client clears its session,
+// anything else becomes a 502. Both mutation routes share this uniform translation.
 async function commit(
   env: Env,
   token: string,
@@ -224,17 +243,16 @@ async function commit(
   path: string,
   payload: Record<string, unknown>,
   action: string
-): Promise<Response | null> {
+): Promise<void> {
   const res = await fetch(contentsUrl(env, path), {
     method,
     headers: { ...ghHeaders(token), 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
   });
-  if (!res.ok) {
-    const detail = await res.text();
-    return json(env, 502, { error: `GitHub rejected the ${action} (${res.status}).`, detail });
-  }
-  return null;
+  if (res.ok) return;
+  if (res.status === 401) throw new ApiError(401, 'Your GitHub sign-in expired. Please sign in again.');
+  const detail = await res.text();
+  throw new ApiError(502, `GitHub rejected the ${action} (${res.status}). ${detail}`.trim());
 }
 
 // UTF-8 safe base64 for the file content GitHub's Contents API expects.
@@ -317,8 +335,7 @@ async function putRecipe(request: Request, env: Env, session: Session): Promise<
   };
   if (existing) payload.sha = existing.sha;
 
-  const err = await commit(env, session.token, 'PUT', path, payload, 'commit');
-  if (err) return err;
+  await commit(env, session.token, 'PUT', path, payload, 'commit');
   return json(env, 200, { ok: true, created: !existing });
 }
 
@@ -330,12 +347,11 @@ async function deleteRecipe(request: Request, env: Env, session: Session): Promi
   const existing = await getExisting(env, session.token, path);
   if (!existing) return json(env, 404, { error: 'That recipe no longer exists.' });
 
-  const err = await commit(env, session.token, 'DELETE', path, {
+  await commit(env, session.token, 'DELETE', path, {
     message: body.message || `Delete recipe: ${body.slug}`,
     sha: existing.sha,
     branch: env.BRANCH,
   }, 'delete');
-  if (err) return err;
   return json(env, 200, { ok: true });
 }
 
@@ -363,13 +379,13 @@ function json(env: Env, status: number, data: unknown): Response {
 }
 
 // Minimal HTML page for OAuth redirect errors (the browser lands here directly, not via fetch).
-function htmlError(message: string): Response {
+function htmlError(message: string, status = 400): Response {
   const safe = message.replace(/</g, '&lt;').replace(/>/g, '&gt;');
   return new Response(
     `<!doctype html><meta charset="utf-8"><title>Sign-in error</title>` +
       `<body style="font-family:system-ui;max-width:32rem;margin:4rem auto;padding:0 1rem">` +
       `<h1>Sign-in error</h1><p>${safe}</p><p><a href="/login">Try again</a></p></body>`,
-    { status: 400, headers: { 'Content-Type': 'text/html; charset=utf-8' } }
+    { status, headers: { 'Content-Type': 'text/html; charset=utf-8' } }
   );
 }
 

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "lib": ["es2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,24 @@
+name = "izzy-recipe-api"
+main = "src/worker.ts"
+compatibility_date = "2024-11-01"
+
+# KV namespace holding session-id → {GitHub token, login}. Create it once with:
+#   npx wrangler kv namespace create SESSIONS
+# then paste the returned id below (and a preview_id for `wrangler dev`).
+[[kv_namespaces]]
+binding = "SESSIONS"
+id = "58e93e762b604bc48498b9127c393d0d"
+preview_id = "930c1eb3c3694e738325eeed83542326"
+
+[vars]
+OWNER = "ibennet"
+REPO = "izzybennett.com"
+BRANCH = "master"
+RECIPE_DIR = "src/content/recipes"
+SITE_ORIGIN = "https://izzybennett.com"
+SESSION_TTL = "28800"        # 8 hours, in seconds
+ALLOWED_LOGIN = "ibennet"    # only this GitHub user may mint a session
+GITHUB_CLIENT_ID = "Ov23liJKTk3X9V904d2f"
+
+# GITHUB_CLIENT_SECRET is a secret, NOT a var. Set it with:
+#   npx wrangler secret put GITHUB_CLIENT_SECRET


### PR DESCRIPTION
## What & why

The `/upload` recipe uploader currently ships as a **fine-grained PAT paste-box** (on the separate `feat/phone-recipe-uploader` branch) — the browser holds a GitHub token in `localStorage` and calls the Contents API directly. This PR replaces that whole flow with a proper **"Sign in with GitHub" OAuth handshake**, so the GitHub token never touches the browser.

Shipping this is what actually kills the FGAP flow — OAuth has been sitting unmerged on this branch, which is why FGAP is still live.

## What changed
- **`worker/`** — new Cloudflare Worker: OAuth login/callback + create/update/delete proxy over the GitHub Contents API. Session tokens live in KV keyed by an opaque id. Hardened with an owner allowlist (only `ibennet` may mint a session), a path guard locking every write to `src/content/recipes/<slug>.md`, least-privilege `public_repo` scope, and CORS scoped to the site origin.
- **`src/pages/upload.astro`** — dropped the token paste-box for a "Sign in with GitHub" bar; the page only ever holds an opaque session id and routes every write through the Worker as a bearer token.
- **`src/pages/recipes.json.ts`** — build-time index feeding the edit picker.
- **`deploy.yml` + `.gitignore`** — inject `PUBLIC_RECIPE_API` at build, ignore worker cruft.
- Follow-up fixes: preserve unmodeled recipe frontmatter on edit (so images don't get yeeted), plus review-finding + error-handling cleanup.

## ⚠️ Deploy checklist (this PR alone doesn't finish the job)
1. **Stand up the Worker** — deploy `worker/`, set the GitHub OAuth app client id/secret + KV binding, wire `PUBLIC_RECIPE_API` into the build.
2. **Retire the FGAP page** — the `feat/phone-recipe-uploader` deployment is a *separate lineage*, so merging this won't tear it down. Kill/repoint that deploy so no PAT paste-box stays live.

## Test plan
- [ ] OAuth login → callback mints a session, non-allowlisted users are rejected
- [ ] Create / update / delete a recipe through the Worker proxy
- [ ] Confirm no GitHub token is ever present client-side (only the opaque session id)
- [ ] Path guard rejects writes outside `src/content/recipes/<slug>.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)