### PR TITLE
feat: sign-in on the recipes page + auth-gated edit/add, gatekeepmaxxing

### DIFF
--- a/src/components/RecipeCard.astro
+++ b/src/components/RecipeCard.astro
@@ -46,7 +46,7 @@ const searchText = [
   <a
     href={`/upload?edit=${recipe.id}`}
     aria-label={`Edit ${title}`}
-    class="shrink-0 rounded px-2 py-1 text-sm text-neutral-300 hover:text-accent-600 dark:text-neutral-600 dark:hover:text-accent-100"
+    class="auth-only shrink-0 rounded px-2 py-1 text-sm text-neutral-300 hover:text-accent-600 dark:text-neutral-600 dark:hover:text-accent-100"
   >
     ✎
   </a>

--- a/src/layouts/RecipeLayout.astro
+++ b/src/layouts/RecipeLayout.astro
@@ -21,7 +21,7 @@ const hasMeta = prepTime !== undefined || cookTime !== undefined || servings !==
 
     <a
       href={`/upload?edit=${recipe.id}`}
-      class="mt-1 inline-flex items-center gap-1 text-xs text-neutral-400 hover:text-accent-600 hover:underline dark:text-neutral-500 dark:hover:text-accent-100"
+      class="auth-only mt-1 inline-flex items-center gap-1 text-xs text-neutral-400 hover:text-accent-600 hover:underline dark:text-neutral-500 dark:hover:text-accent-100"
     >
       ✎ Edit recipe
     </a>
@@ -107,3 +107,11 @@ const hasMeta = prepTime !== undefined || cookTime !== undefined || servings !==
     )}
   </article>
 </BaseLayout>
+
+<script>
+  import { applyAuthState } from '../scripts/recipe-session';
+
+  // Reveal the edit link only when signed in. OAuth never returns to a detail page, so there's no
+  // hash to ingest here — just reflect the stored session onto <html data-auth> and let CSS gate.
+  applyAuthState();
+</script>

--- a/src/pages/recipes/index.astro
+++ b/src/pages/recipes/index.astro
@@ -4,6 +4,10 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import RecipeCard from '../../components/RecipeCard.astro';
 import { categoryValues } from '../../content.config';
 
+// Base URL of the recipe API Worker (the OAuth backend). Injected at build time; falls back to
+// the local `wrangler dev` port so `astro dev` works out of the box. Mirrors /upload.
+const RECIPE_API = import.meta.env.PUBLIC_RECIPE_API ?? 'http://localhost:8787';
+
 const recipes = (await getCollection('recipes', ({ data }) => !data.draft)).sort((a, b) =>
   a.data.title.localeCompare(b.data.title)
 );
@@ -16,7 +20,28 @@ const filters = ['', ...categories];
 ---
 
 <BaseLayout title="Recipes" description="An archive of Izzy Bennett's recipes.">
-  <h1 class="text-3xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">Recipes</h1>
+  <div class="flex flex-wrap items-center justify-between gap-3">
+    <h1 class="text-3xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">Recipes</h1>
+
+    <!-- Auth controls. Visibility is CSS-gated off <html data-auth> (see global.css + the session
+         script below): `.auth-when-out` shows signed-out, `.auth-only` shows signed-in. Sign-in
+         kicks off GitHub OAuth on the Worker and returns to /recipes/ (see the return_to param). -->
+    <div class="flex items-center gap-3">
+      <a href={`${RECIPE_API}/login?return_to=/recipes/`}
+        class="auth-when-out rounded-lg bg-neutral-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-neutral-700 dark:bg-white dark:text-neutral-900 dark:hover:bg-neutral-200">
+        Sign in with GitHub
+      </a>
+      <a href="/upload"
+        class="auth-only rounded-lg bg-accent-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-accent-700">
+        + Add new recipe
+      </a>
+      <span class="auth-only text-sm text-green-600 dark:text-green-500">✓ Signed in</span>
+      <button type="button" id="signout-btn" data-api={RECIPE_API}
+        class="auth-only rounded-lg border border-neutral-300 px-3 py-1.5 text-sm font-medium text-neutral-700 hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800">
+        Sign out
+      </button>
+    </div>
+  </div>
   <p class="mt-2 text-neutral-600 dark:text-neutral-400">An archive</p>
 
   <div class="mt-6">
@@ -89,4 +114,18 @@ const filters = ['', ...categories];
       applyFilters();
     });
   }
+</script>
+
+<script>
+  import { ingestSessionFromHash, applyAuthState, signOut } from '../../scripts/recipe-session';
+
+  // The Worker's OAuth return URL for this page is the signed-in Worker base, carried on the
+  // sign-out button's data-api so the module stays free of build-time env injection.
+  const signoutBtn = document.getElementById('signout-btn');
+  signoutBtn?.addEventListener('click', () => signOut(signoutBtn.dataset.api ?? ''));
+
+  // Ingest a just-returned OAuth session, then reflect signed-in state so the CSS reveals the
+  // right controls (sign-in when out; Add / signed-in / sign-out / per-card pencils when in).
+  ingestSessionFromHash();
+  applyAuthState();
 </script>

--- a/src/scripts/recipe-session.ts
+++ b/src/scripts/recipe-session.ts
@@ -1,0 +1,42 @@
+// Shared client-side recipe auth/session helpers, used by any page that surfaces sign-in or gates
+// editing affordances (the recipes index and each recipe detail page). The browser only ever holds
+// the opaque session id under SESSION_KEY — never a GitHub token.
+//
+// Gating is CSS-driven: `applyAuthState()` reflects signed-in state onto <html data-auth>, and
+// global.css reveals `.auth-only` (signed in) / `.auth-when-out` (signed out) from that one flag.
+// (Note: /upload keeps its own inline copy — its `define:vars` script can't import a module.)
+export const SESSION_KEY = 'izzy-recipe-session';
+
+export const currentSession = (): string | null => localStorage.getItem(SESSION_KEY);
+export const clearSession = (): void => localStorage.removeItem(SESSION_KEY);
+
+// Reflect signed-in state onto the document root so the CSS gating rules take over — no per-element
+// class toggling, so it can't clash with an element's own `display` utility.
+export function applyAuthState(): void {
+  document.documentElement.dataset.auth = currentSession() ? 'in' : 'out';
+}
+
+// On return from OAuth the Worker redirects to <page>#session=<id>. Pull it out of the fragment
+// (fragments never hit a server or log), stash it, then scrub the URL.
+export function ingestSessionFromHash(): void {
+  const prefix = '#session=';
+  if (location.hash.startsWith(prefix)) {
+    const id = location.hash.slice(prefix.length);
+    if (id) localStorage.setItem(SESSION_KEY, id);
+    history.replaceState(null, '', location.pathname + location.search);
+  }
+}
+
+// Best-effort server-side revoke; the local session is cleared and the UI re-gated regardless.
+export async function signOut(apiBase: string): Promise<void> {
+  const session = currentSession();
+  if (session) {
+    try {
+      await fetch(`${apiBase}/logout`, { method: 'POST', headers: { Authorization: `Bearer ${session}` } });
+    } catch {
+      /* offline is fine — we still drop the local id */
+    }
+  }
+  clearSession();
+  applyAuthState();
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -13,3 +13,13 @@
 body {
   font-family: var(--font-sans);
 }
+
+/* Client-side auth gating. Elements stay hidden until the shared session script stamps
+   <html data-auth="in|out"> (see src/scripts/recipe-session.ts). The `:not()` selectors apply
+   `display: none` only in the non-matching state and never touch `display` in the shown state, so a
+   revealed element keeps its own display (inline-flex, flex, …) with no wrapper needed. Before the
+   script runs neither attribute is set, so both stay hidden — the safe, signed-out view. */
+:root:not([data-auth="in"]) .auth-only,
+:root:not([data-auth="out"]) .auth-when-out {
+  display: none;
+}

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -40,6 +40,19 @@ const GH_OAUTH = 'https://github.com/login/oauth';
 const UA = 'izzy-recipe-worker';
 const SLUG_RE = /^[a-z0-9-]+$/;
 
+// Pages sign-in may return to. An allowlist (not raw reflection of `return_to`) keeps the
+// post-OAuth redirect from becoming an open redirect. First entry is the default fallback.
+const RETURN_PATHS = ['/upload', '/recipes/'];
+const DEFAULT_RETURN = RETURN_PATHS[0];
+const safeReturn = (path: string | null): string =>
+  path && RETURN_PATHS.includes(path) ? path : DEFAULT_RETURN;
+
+// The two first-party OAuth cookies in their cleared (Max-Age=0) form. Appended on every callback
+// exit — success or failure — so a half-finished sign-in never leaves them lingering in the browser.
+const CLEAR_AUTH_COOKIES = ['oauth_state', 'oauth_return'].map(
+  (name) => `${name}=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0`
+);
+
 // Top-level frontmatter keys the /upload form owns and re-serializes on every save. Any OTHER
 // key found in an existing recipe (e.g. `image`) is NOT modelled by the form, so on update we
 // carry it over from the old file — otherwise editing a recipe through /upload would silently
@@ -67,7 +80,7 @@ export default {
         case 'GET /callback':
           // A browser navigation lands here, so surface failures as the friendly HTML page.
           return await handleCallback(request, url, env).catch(() =>
-            htmlError('Something went wrong during sign-in. Please try again.')
+            htmlError('Something went wrong during sign-in. Please try again.', 400, CLEAR_AUTH_COOKIES)
           );
         case 'POST /api/recipe':
           return await withSession(request, env, (_id, s) => putRecipe(request, env, s));
@@ -102,6 +115,7 @@ class ApiError extends Error {
 
 function handleLogin(url: URL, env: Env): Response {
   const state = crypto.randomUUID();
+  const returnTo = safeReturn(url.searchParams.get('return_to'));
   const authorize = new URL(`${GH_OAUTH}/authorize`);
   authorize.searchParams.set('client_id', env.GITHUB_CLIENT_ID);
   authorize.searchParams.set('redirect_uri', `${url.origin}/callback`);
@@ -109,14 +123,13 @@ function handleLogin(url: URL, env: Env): Response {
   authorize.searchParams.set('state', state);
   authorize.searchParams.set('allow_signup', 'false');
 
-  // Stash the state in a short-lived, first-party (worker-origin) cookie to check on callback.
-  return new Response(null, {
-    status: 302,
-    headers: {
-      Location: authorize.toString(),
-      'Set-Cookie': `oauth_state=${state}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=600`,
-    },
-  });
+  // Stash the state (checked on callback) and the return path (where to land after) in short-lived,
+  // first-party (worker-origin) cookies. Two Set-Cookie headers, hence a Headers instance.
+  const headers = new Headers({ Location: authorize.toString() });
+  const cookieOpts = 'HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=600';
+  headers.append('Set-Cookie', `oauth_state=${state}; ${cookieOpts}`);
+  headers.append('Set-Cookie', `oauth_return=${returnTo}; ${cookieOpts}`);
+  return new Response(null, { status: 302, headers });
 }
 
 // ---- OAuth: callback ------------------------------------------------------
@@ -127,7 +140,7 @@ async function handleCallback(request: Request, url: URL, env: Env): Promise<Res
   const cookieState = readCookie(request, 'oauth_state');
 
   if (!code || !state || !cookieState || state !== cookieState) {
-    return htmlError('Sign-in failed: invalid or expired state. Please try again.');
+    return htmlError('Sign-in failed: invalid or expired state. Please try again.', 400, CLEAR_AUTH_COOKIES);
   }
 
   // Exchange the code for a token — the only place the client secret is used.
@@ -144,7 +157,7 @@ async function handleCallback(request: Request, url: URL, env: Env): Promise<Res
   const tokenData = (await tokenRes.json()) as { access_token?: string; error?: string };
   const token = tokenData.access_token;
   if (!token) {
-    return htmlError(`Sign-in failed: ${tokenData.error ?? 'no token returned'}.`);
+    return htmlError(`Sign-in failed: ${tokenData.error ?? 'no token returned'}.`, 400, CLEAR_AUTH_COOKIES);
   }
 
   // Identify the user and gate on the allowlist — the OAuth App is public, so anyone could
@@ -154,7 +167,7 @@ async function handleCallback(request: Request, url: URL, env: Env): Promise<Res
   });
   const user = (await userRes.json()) as { login?: string };
   if (!user.login || user.login.toLowerCase() !== env.ALLOWED_LOGIN.toLowerCase()) {
-    return htmlError(`Sorry, @${user.login ?? 'unknown'} is not allowed to edit recipes.`, 403);
+    return htmlError(`Sorry, @${user.login ?? 'unknown'} is not allowed to edit recipes.`, 403, CLEAR_AUTH_COOKIES);
   }
 
   // Mint an opaque session id; the GitHub token stays server-side in KV.
@@ -163,15 +176,14 @@ async function handleCallback(request: Request, url: URL, env: Env): Promise<Res
   const session: Session = { token };
   await env.SESSIONS.put(sessionId, JSON.stringify(session), { expirationTtl: ttl });
 
+  // Return to whichever page started sign-in (re-validated against the allowlist, defensively).
+  const returnTo = safeReturn(readCookie(request, 'oauth_return'));
+
   // Hand the session id back via the URL fragment — fragments aren't sent to servers or logged.
-  // Also clear the state cookie.
-  return new Response(null, {
-    status: 302,
-    headers: {
-      Location: `${env.SITE_ORIGIN}/upload#session=${sessionId}`,
-      'Set-Cookie': 'oauth_state=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0',
-    },
-  });
+  // Also clear both the state and return cookies.
+  const headers = new Headers({ Location: `${env.SITE_ORIGIN}${returnTo}#session=${sessionId}` });
+  for (const cookie of CLEAR_AUTH_COOKIES) headers.append('Set-Cookie', cookie);
+  return new Response(null, { status: 302, headers });
 }
 
 // ---- Session auth wrapper -------------------------------------------------
@@ -379,13 +391,16 @@ function json(env: Env, status: number, data: unknown): Response {
 }
 
 // Minimal HTML page for OAuth redirect errors (the browser lands here directly, not via fetch).
-function htmlError(message: string, status = 400): Response {
+// Optional `cookies` are appended as Set-Cookie headers — callback failures pass CLEAR_AUTH_COOKIES.
+function htmlError(message: string, status = 400, cookies: string[] = []): Response {
   const safe = message.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  const headers = new Headers({ 'Content-Type': 'text/html; charset=utf-8' });
+  for (const cookie of cookies) headers.append('Set-Cookie', cookie);
   return new Response(
     `<!doctype html><meta charset="utf-8"><title>Sign-in error</title>` +
       `<body style="font-family:system-ui;max-width:32rem;margin:4rem auto;padding:0 1rem">` +
       `<h1>Sign-in error</h1><p>${safe}</p><p><a href="/login">Try again</a></p></body>`,
-    { status, headers: { 'Content-Type': 'text/html; charset=utf-8' } }
+    { status, headers }
   );
 }
 


### PR DESCRIPTION
## What's poppin'
Moves GitHub OAuth sign-in onto the recipes list itself and gates the editing affordances behind it. Signed-out visitors get a clean read-only page; signing in unlocks **Add new recipe**, the per-recipe ✎ edit pencils, and the detail-page edit link. No more edit buttons flexing on logged-out randos.

## Changes
- **Worker** (`worker/src/worker.ts`): `/login` takes an allowlisted `return_to` (no open-redirect) and the callback returns to whichever page started sign-in instead of always dumping you on `/upload`. Both OAuth cookies are now cleared on **every** callback exit — success or failure — so a bailed sign-in leaves nothing lingering.
- **Shared module** (`src/scripts/recipe-session.ts`): one home for the session helpers (key, ingest-from-hash, sign-out, `applyAuthState`) instead of copy-paste across pages.
- **CSS-driven gating**: visibility keys off `<html data-auth>` via `:not()` selectors, so a revealed element keeps its own display utility — no wrapper hacks, no flash of edit buttons before JS runs, fail-closed when signed out.

## Verification
- `npm run build` ✅ (25 pages) · worker `tsc --noEmit` ✅ · `astro check` clean (only the pre-existing `KVNamespace` false-positive)
- Confirmed in built output: `return_to=/recipes/` sign-in link, `:not([data-auth])` gating rule bundled, all auth elements hidden by SSR default
- Ran `/simplify` (extracted the shared module, collapsed the gating) and `/code-review` (fixed the `display:revert` footgun + cookie-clearing on error paths)

> ⚠️ **Deploy still needed**: the live `return_to` redirect only takes effect after the Worker is deployed (`cd worker && npx wrangler deploy`). Until then, signing in from `/recipes/` still returns to `/upload` on production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)