### PR TITLE
content: shrink cafe menu (Coffee/Matcha, Syrups), trimmaxxing

### DIFF
--- a/src/content/pages/izzys-cafe.md
+++ b/src/content/pages/izzys-cafe.md
@@ -5,19 +5,16 @@ title: "Izzy's Cafe"
 ## Menu
 
 #### Drinks
-- Latte
-- Matcha Latte
-- Americano
-- Pourover
+- Coffee
+- Matcha
 
 #### Milks
 - Whole
 - Oat
 
-#### Additions
-- Cardamom syrup
-- Cardamom cold foam
-- Ice
+#### Syrups
+- Cardamom
+- Earl Gray
 
 #### Food
 - Cardamom cookie


### PR DESCRIPTION
## What
Trims the Izzy's Cafe menu content in `src/content/pages/izzys-cafe.md`:
- **Drinks:** Coffee, Matcha (was Latte / Matcha Latte / Americano / Pourover)
- **Additions → Syrups:** Cardamom, Earl Gray
- **Milks / Food:** unchanged

## Why
The [dizzyos](https://github.com/ibennet/dizzyos) LED sign renders this menu from the live `/izzys-cafe.json` feed. Fewer, shorter items let the sign auto-select a larger pixel font (5×8 instead of 4×6) and stay fully legible on the 128×64 panel. This markdown is the single source of truth, so the site page and the sign both update from here.

## Verified
`npx astro build` → `dist/izzys-cafe.json` serves the new sections. dizzyos renders it at the larger font with everything on-screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)