### PR TITLE
fix: unbreak Pages deploy — migrate Earl Grey steps to grouped schema, buildmaxxing

### DIFF
--- a/src/content/recipes/earl-grey-pound-cake.md
+++ b/src/content/recipes/earl-grey-pound-cake.md
@@ -39,5 +39,6 @@ ingredients:
       - "1/2 tsp lavender extract"
       - "2 tbsp (30ml) heavy cream"
 steps:
-  - "step 1"
+  - items:
+      - "step 1"
 ---


### PR DESCRIPTION
## What broke

The last two `Deploy to GitHub Pages` runs on `master` failed at `npm run build`:

```
[InvalidContentEntryDataError] recipes → earl-grey-pound-cake data does not match collection schema.
  steps.0: Expected type "object", received "string"
```

## Root cause

Commit `8366daf` (step groups + drag-to-reorder) changed the `steps` schema in `src/content.config.ts` from `z.array(z.string())` to grouped `{ group?, items[] }` objects — matching `ingredients` — and migrated all 18 existing recipes. But `earl-grey-pound-cake.md` landed in parallel (`4505bef`) with the old plain-string `steps`, so the migration missed it. Astro fails the build on the first offending entry, tanking every deploy since.

## Fix

Wrap the stub step in the grouped structure the rest of the content already uses:

```yaml
steps:
  - items:
      - "step 1"
```

## Verified

`npm ci && npm run build` now completes — 25 pages built, incl. `/recipes/earl-grey-pound-cake/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)