### PR TITLE
feat: dark-pink "IB" favicon, tabmaxxing

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <text x="16" y="17" fill="#db2777" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="20" font-weight="700" letter-spacing="-1" text-anchor="middle" dominant-baseline="central">IB</text>
+</svg>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -16,7 +16,8 @@ const { title, description = "Izzy Bennett's personal website — resume, recipe
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" href="/favicon.ico" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
     <meta name="description" content={description} />
     <meta name="generator" content={Astro.generator} />
     <title>{title} · Izzy Bennett</title>

--- a/src/pages/upload.astro
+++ b/src/pages/upload.astro
@@ -39,7 +39,8 @@ const dragHandle =
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="robots" content="noindex, nofollow" />
     <meta name="theme-color" content="#db2777" />
-    <link rel="icon" href="/favicon.ico" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
     <title>Add a recipe · Izzy Bennett</title>
   </head>
   <body class="min-h-screen bg-white text-neutral-800 dark:bg-neutral-950 dark:text-neutral-200">


### PR DESCRIPTION
## What
Replaces the generic browser-tab icon with the initials **IB** in the brand's dark pink (`#db2777`), per request.

## Changes
- **New:** `public/favicon.svg` — "IB" wordmark, `#db2777` fill, transparent background, letters-only (no badge). SVG stays crisp at every tab size.
- **`src/layouts/BaseLayout.astro`** & **`src/pages/upload.astro`** — load the SVG first via `<link rel="icon" type="image/svg+xml">`, with the existing `favicon.ico` kept as a legacy fallback (`sizes="any"`) for browsers without SVG-favicon support.

## Design notes
- Color is the primary brand pink `--color-accent-600` (`#db2777`), matching the site's links and the `theme-color` meta.
- Letters-only on a transparent background was the chosen style. Heads up: on a dark browser tab the pink can read slightly low-contrast — easy to switch to a filled pink badge later if you want more pop.

## Verification
- Rendered `public/favicon.svg` to a raster image → shows a clean pink "IB". SVG validates as well-formed XML.
- Diff is scoped to the SVG + two `<head>` links; `favicon.ico` and `dist/` untouched.
- ⚠️ Could not run a full `astro build` — it fails on a **pre-existing, unrelated** content-schema error in `src/content/recipes/earl-grey-pound-cake.md` (recipe `steps` are strings where the schema expects objects). Not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)