### PR TITLE
feat: hover/tap ingredient measurements in recipe steps, hovermaxxing (#20)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.10",
-        "typescript": "^6.0.3"
+        "typescript": "^6.0.3",
+        "vitest": "^3.2.4"
       },
       "engines": {
         "node": ">=22.12.0"
@@ -1728,6 +1729,25 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
@@ -2058,6 +2078,370 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@shikijs/core": {
       "version": "4.4.1",
@@ -2720,6 +3104,24 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -2773,6 +3175,104 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
       "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
       "license": "ISC"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/@volar/kit": {
       "version": "2.4.28",
@@ -2999,6 +3499,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/astro": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/astro/-/astro-7.1.6.tgz",
@@ -3108,6 +3618,16 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ccount": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -3116,6 +3636,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities-html4": {
@@ -3136,6 +3673,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -3351,6 +3898,34 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
       "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "license": "CC0-1.0"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/defu": {
       "version": "6.1.7",
@@ -3603,6 +4178,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -3957,6 +4542,13 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
@@ -4263,6 +4855,13 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "11.5.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
@@ -4428,6 +5027,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/muggle-string": {
       "version": "0.4.1",
@@ -4623,6 +5229,23 @@
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/piccolore": {
       "version": "0.1.3",
@@ -4850,6 +5473,52 @@
         "@rolldown/binding-win32-x64-msvc": "1.2.1"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/satteri": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.9.5.tgz",
@@ -4963,6 +5632,13 @@
         "node": ">=20"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -4999,6 +5675,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "8.2.2",
@@ -5045,6 +5735,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/svgo": {
@@ -5097,6 +5800,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyclip": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.15.tgz",
@@ -5129,6 +5839,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/trim-lines": {
@@ -5526,6 +6266,111 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vitefu": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
@@ -5541,6 +6386,208 @@
       },
       "peerDependenciesMeta": {
         "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
           "optional": true
         }
       }
@@ -5836,6 +6883,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.10",
+        "happy-dom": "^20.11.2",
         "typescript": "^6.0.3",
         "vitest": "^3.2.4"
       },
@@ -3164,11 +3165,38 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.3",
@@ -3617,6 +3645,19 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -4369,6 +4410,38 @@
         "radix3": "^1.1.2",
         "ufo": "^1.6.3",
         "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.11.2",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.2.tgz",
+      "integrity": "sha512-7MB+bJLkxu3SowAfBJbjW+c55kNz5tkR45gu2qzrxznezhLeN5YIlJbwUgSzlGc+qWoZ8Ykg71H5ezz69xixrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/hast-util-from-html": {
@@ -5947,6 +6020,13 @@
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
     },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/unified": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -6885,6 +6965,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -6936,6 +7026,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xxhash-wasm": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test": "vitest run"
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.20",
@@ -20,6 +21,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.10",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.10",
+    "happy-dom": "^20.11.2",
     "typescript": "^6.0.3",
     "vitest": "^3.2.4"
   }

--- a/src/data/densities.json
+++ b/src/data/densities.json
@@ -7,6 +7,8 @@
   "sugar": 200,
   "white sugar": 200,
   "granulated sugar": 200,
+  "greek yogurt": 230,
+  "yogurt": 230,
   "brown sugar": 220,
   "powdered sugar": 120,
   "salt": 288,

--- a/src/layouts/RecipeLayout.astro
+++ b/src/layouts/RecipeLayout.astro
@@ -3,6 +3,7 @@ import BaseLayout from './BaseLayout.astro';
 import type { CollectionEntry } from 'astro:content';
 import { inlineMarkdown } from '../lib/markdown';
 import { toGrams, formatGrams, ingredientLabel, type Densities } from '../lib/units';
+import { buildIngredientIndex, linkIngredientsInHtml } from '../lib/ingredients';
 import densityData from '../data/densities.json';
 
 interface Props {
@@ -28,6 +29,12 @@ const ingredientGroups = ingredients.map((group) => ({
   }),
 }));
 const anyConvertible = ingredientGroups.some((group) => group.items.some((item) => item.grams !== null));
+
+// Index the recipe's ingredients so mentions in the step prose can be linked to their
+// measurement. `idState` threads a single counter through every step so each popover
+// gets a page-unique id for its aria-describedby.
+const ingredientIndex = buildIngredientIndex(ingredients);
+const popoverIds = { n: 0 };
 ---
 
 <BaseLayout title={title} description={description}>
@@ -124,7 +131,7 @@ const anyConvertible = ingredientGroups.some((group) => group.items.some((item) 
                   <span class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent-50 text-xs font-medium text-accent-700 dark:bg-neutral-800 dark:text-accent-100">
                     {i + 1}
                   </span>
-                  <span class="text-neutral-700 dark:text-neutral-300" set:html={inlineMarkdown(step)} />
+                  <span class="text-neutral-700 dark:text-neutral-300" set:html={linkIngredientsInHtml(inlineMarkdown(step), ingredientIndex, popoverIds)} />
                 </li>
               ))}
             </ol>
@@ -159,10 +166,15 @@ const anyConvertible = ingredientGroups.some((group) => group.items.some((item) 
 
 <script>
   import { applyAuthState } from '../scripts/recipe-session';
+  import { initIngredientPopovers } from '../scripts/ingredient-popover';
 
   // Reveal the edit link only when signed in. OAuth never returns to a detail page, so there's no
   // hash to ingest here — just reflect the stored session onto <html data-auth> and let CSS gate.
   applyAuthState();
+
+  // Tap-toggle + dismissal for the ingredient-measurement popovers in the steps (hover/focus
+  // are pure CSS; this only adds touch and Escape/outside-click behavior).
+  initIngredientPopovers();
 
   // Ingredient unit toggle (US ↔ Grams). The choice is stored so it carries across recipes.
   const UNITS_KEY = 'izzy-recipe-units';

--- a/src/layouts/RecipeLayout.astro
+++ b/src/layouts/RecipeLayout.astro
@@ -33,7 +33,10 @@ const anyConvertible = ingredientGroups.some((group) => group.items.some((item) 
 // Index the recipe's ingredients so mentions in the step prose can be linked to their
 // measurement. `idState` threads a single counter through every step so each popover
 // gets a page-unique id for its aria-describedby.
-const ingredientIndex = buildIngredientIndex(ingredients);
+const ingredientIndex = buildIngredientIndex(ingredients, (item) => {
+  const grams = toGrams(item.qty, item.unit, item.name, densities);
+  return grams === null ? null : formatGrams(grams);
+});
 const popoverIds = { n: 0 };
 ---
 
@@ -187,6 +190,9 @@ const popoverIds = { n: 0 };
     const apply = (units: string) => {
       const mode = units === 'grams' ? 'grams' : 'us';
       list.dataset.units = mode;
+      // Also reflect the mode on <html> so the step popovers (outside #ingredients-list)
+      // switch US ↔ grams with the same toggle.
+      document.documentElement.dataset.units = mode;
       for (const btn of buttons) {
         const on = btn.dataset.unitsBtn === mode;
         btn.setAttribute('aria-pressed', String(on));

--- a/src/lib/ingredients.test.ts
+++ b/src/lib/ingredients.test.ts
@@ -17,7 +17,7 @@ const cookies: IngredientGroup[] = [
   },
 ];
 
-// Mirrors apple-bread.md (grouped, with duplicate names across groups + prep-prefixed names).
+// Mirrors apple-bread.md (grouped, duplicate names across groups + prep-prefixed names).
 const appleBread: IngredientGroup[] = [
   {
     group: 'Bread layer',
@@ -46,6 +46,30 @@ const appleBread: IngredientGroup[] = [
   },
 ];
 
+// Mirrors earl-grey-pound-cake.md — heavily qualified names, short prose references.
+const earlGrey: IngredientGroup[] = [
+  {
+    group: 'Wet Ingredients',
+    items: [
+      { name: 'unsalted butter, room temp', qty: '1', unit: 'cup' },
+      { name: 'vegetable oil', qty: '1/4', unit: 'cup' },
+      { name: 'granulated sugar', qty: '1 3/4', unit: 'cup' },
+      { name: 'Greek yogurt, room temp', qty: '1/2', unit: 'cup' },
+      { name: 'vanilla bean paste', qty: '1', unit: 'tsp' },
+      { name: 'lavender paste (or extract)', qty: '1', unit: 'tsp' },
+    ],
+  },
+  {
+    group: 'Buttercream Ingredients',
+    items: [
+      { name: 'unsalted butter, softened', qty: '3/4', unit: 'cup' },
+      { name: 'powdered sugar', qty: '2', unit: 'cup' },
+      { name: 'vanilla bean paste', qty: '1 1/2', unit: 'tsp' },
+      { name: 'lavender extract', qty: '1/2', unit: 'tsp' },
+    ],
+  },
+];
+
 /** Render a step and strip it back to "label→popover-text" pairs for easy assertions. */
 function linked(step: string, groups: IngredientGroup[]): Array<[string, string]> {
   const html = linkIngredientsInHtml(step, buildIngredientIndex(groups), { n: 0 });
@@ -53,55 +77,94 @@ function linked(step: string, groups: IngredientGroup[]): Array<[string, string]
   const re = /<button[^>]*>([^<]*)<\/button><span[^>]*class="ing-pop"[^>]*>(.*?)<\/span><\/span>/g;
   let m: RegExpExecArray | null;
   while ((m = re.exec(html)) !== null) {
-    out.push([m[1], m[2].replace(/<[^>]+>/g, '').trim()]);
+    out.push([m[1], m[2].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim()]);
   }
   return out;
 }
 
-describe('buildIngredientIndex', () => {
-  it('excludes items with no measurement', () => {
-    const { lookup } = buildIngredientIndex(cookies);
-    expect(lookup.has('oil spray')).toBe(false);
-    expect(lookup.get('flour')).toEqual([{ measurement: '1 ½ cup', group: undefined }]);
-  });
+/** Full rendered HTML for a step. */
+function render(step: string, groups: IngredientGroup[]): string {
+  return linkIngredientsInHtml(step, buildIngredientIndex(groups), { n: 0 });
+}
 
-  it('keeps a count-only measurement (no unit)', () => {
-    const { lookup } = buildIngredientIndex(cookies);
-    expect(lookup.get('egg')).toEqual([{ measurement: '1', group: undefined }]);
-  });
+/** How many ingredient triggers a step produced. */
+function triggerCount(html: string): number {
+  return (html.match(/class="ing-ref"/g) ?? []).length;
+}
 
-  it('collects every measurement for a name repeated across groups', () => {
-    const { lookup } = buildIngredientIndex(appleBread);
-    expect(lookup.get('vanilla extract')).toEqual([
-      { measurement: '1 ½ tsp', group: 'Bread layer' },
-      { measurement: '½ tsp', group: 'Icing' },
-    ]);
-    expect(lookup.get('oat milk')).toHaveLength(2);
-  });
-});
-
-describe('linkIngredientsInHtml — matching', () => {
-  it('matches a plain single-word name', () => {
+describe('measurement resolution', () => {
+  it('resolves a plain single-word name', () => {
     expect(linked('mix the flour well', cookies)).toEqual([['flour', '1 ½ cup']]);
   });
 
+  it('keeps a count-only measurement (no unit)', () => {
+    expect(linked('add the egg', cookies)).toEqual([['egg', '1']]);
+  });
+
+  it('excludes items with no measurement', () => {
+    expect(linked('spray the pan with oil spray', cookies)).toEqual([]);
+  });
+});
+
+describe('longest-match & specificity', () => {
   it('prefers the longest name (brown sugar, not sugar)', () => {
-    const hits = linked('add brown sugar and white sugar', cookies);
-    expect(hits).toEqual([
+    expect(linked('add brown sugar and white sugar', cookies)).toEqual([
       ['brown sugar', '½ cup'],
       ['white sugar', '6 tbsp'],
     ]);
   });
 
-  it('does not match a plain "sugar" mention as brown/white sugar', () => {
-    // apple-bread has a standalone "sugar" ingredient.
+  it('a real "sugar" ingredient wins over another name\'s generic alias', () => {
+    // apple-bread has a standalone "sugar"; "brown sugar" also aliases to "sugar" generically,
+    // but the specific full-name match must win, so plain "sugar" resolves to just ⅔ cup.
     expect(linked('cream the butter and sugar', appleBread)).toEqual([
-      ['butter', '8 tbsp'], // matched via prep-stripped alias of "softened butter"
+      ['butter', '8 tbsp'],
       ['sugar', '⅔ cup'],
     ]);
   });
+});
 
-  it('matches through a leading prep adjective (medium apples → apples)', () => {
+describe('qualified names ↔ short prose (earl grey)', () => {
+  it('matches a head noun through a type qualifier (vegetable oil → oil)', () => {
+    expect(linked('beat in the oil', earlGrey)).toEqual([['oil', '1/4 cup']]);
+  });
+
+  it('matches through a trailing descriptor (vanilla bean paste → vanilla)', () => {
+    // vanilla bean paste appears in both groups → both measurements, with group labels.
+    const html = render('mix in the vanilla', earlGrey);
+    expect(triggerCount(html)).toBe(1);
+    expect(html).toContain('1 tsp');
+    expect(html).toContain('Wet Ingredients');
+    expect(html).toContain('1 1/2 tsp');
+    expect(html).toContain('Buttercream Ingredients');
+  });
+
+  it('collapses lavender paste / extract to one "lavender" mention with both amounts', () => {
+    const html = render('add the lavender', earlGrey);
+    expect(triggerCount(html)).toBe(1);
+    expect(html).toContain('1 tsp');
+    expect(html).toContain('1/2 tsp');
+  });
+
+  it('resolves a bare "sugar" to every sugar when there is no plain one', () => {
+    const html = render('add the sugar', earlGrey);
+    expect(html).toContain('1 3/4 cup'); // granulated
+    expect(html).toContain('2 cup'); // powdered
+  });
+
+  it('still prefers the specific "powdered sugar" over the shared "sugar" alias', () => {
+    expect(linked('add the powdered sugar', earlGrey)).toEqual([['powdered sugar', '2 cup']]);
+  });
+
+  it('matches "butter" for both unsalted butters', () => {
+    const html = render('beat the butter', earlGrey);
+    expect(html).toContain('1 cup');
+    expect(html).toContain('3/4 cup');
+  });
+});
+
+describe('number agreement & boundaries', () => {
+  it('matches a leading prep adjective via head noun (medium apples → apples)', () => {
     expect(linked('peel the apples', appleBread)).toEqual([['apples', '2']]);
   });
 
@@ -118,12 +181,6 @@ describe('linkIngredientsInHtml — matching', () => {
     expect(linked('use salted butter', salt)).toEqual([]);
   });
 
-  it('renders an ambiguous name as rows with group labels', () => {
-    const html = linkIngredientsInHtml('stir in the oat milk', buildIngredientIndex(appleBread), { n: 0 });
-    expect(html).toContain('½ cup <span class="ing-pop-group">· Bread layer</span>');
-    expect(html).toContain('2 tbsp <span class="ing-pop-group">· Icing</span>');
-  });
-
   it('wraps every occurrence with a unique id', () => {
     const html = linkIngredientsInHtml('flour, then more flour', buildIngredientIndex(cookies), { n: 0 });
     expect(html).toContain('id="ing-pop-0"');
@@ -131,7 +188,28 @@ describe('linkIngredientsInHtml — matching', () => {
   });
 });
 
-describe('linkIngredientsInHtml — HTML safety', () => {
+describe('grams rendering', () => {
+  // Stub gramsOf: grams only for cup measurements, to mirror the real convertible/not split.
+  const gramsOf = (item: { qty?: string; unit?: string }) =>
+    item.unit === 'cup' ? '227 g' : null;
+
+  it('bakes both US and grams into a convertible amount, marked convertible', () => {
+    const idx = buildIngredientIndex(cookies, gramsOf);
+    const html = linkIngredientsInHtml('mix the flour', idx, { n: 0 });
+    expect(html).toContain('<span class="ing-amt ing-conv">');
+    expect(html).toContain('<span class="ing-us">1 ½ cup</span>');
+    expect(html).toContain('<span class="ing-grams">227 g</span>');
+  });
+
+  it('omits grams (and the convertible flag) for a count-only amount', () => {
+    const idx = buildIngredientIndex(cookies, gramsOf);
+    const html = linkIngredientsInHtml('add the egg', idx, { n: 0 });
+    expect(html).toContain('<span class="ing-amt">'); // not ing-conv
+    expect(html).not.toContain('ing-grams');
+  });
+});
+
+describe('HTML safety', () => {
   const idx = () => buildIngredientIndex(cookies);
 
   it('leaves markdown tags intact and still matches text inside them', () => {

--- a/src/lib/ingredients.test.ts
+++ b/src/lib/ingredients.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { buildIngredientIndex, linkIngredientsInHtml, type IngredientGroup } from './ingredients';
+
+// Mirrors chocochip-cookies.md (single unnamed group).
+const cookies: IngredientGroup[] = [
+  {
+    items: [
+      { name: 'Oil spray' },
+      { name: 'butter, softened', qty: '½', unit: 'cup' },
+      { name: 'brown sugar', qty: '½', unit: 'cup' },
+      { name: 'white sugar', qty: '6', unit: 'tbsp' },
+      { name: 'vanilla extract', qty: '1', unit: 'tsp' },
+      { name: 'egg', qty: '1' },
+      { name: 'flour', qty: '1 ½', unit: 'cup' },
+      { name: 'chocolate chips', qty: '6', unit: 'oz' },
+    ],
+  },
+];
+
+// Mirrors apple-bread.md (grouped, with duplicate names across groups + prep-prefixed names).
+const appleBread: IngredientGroup[] = [
+  {
+    group: 'Bread layer',
+    items: [
+      { name: 'softened butter', qty: '8', unit: 'tbsp' },
+      { name: 'sugar', qty: '⅔', unit: 'cup' },
+      { name: 'eggs', qty: '2' },
+      { name: 'vanilla extract', qty: '1 ½', unit: 'tsp' },
+      { name: 'oat milk', qty: '½', unit: 'cup' },
+    ],
+  },
+  {
+    group: 'Apple layer',
+    items: [
+      { name: 'brown sugar', qty: '½', unit: 'cup' },
+      { name: 'ground cinnamon', qty: '2', unit: 'tsp' },
+      { name: 'medium apples', qty: '2' },
+    ],
+  },
+  {
+    group: 'Icing',
+    items: [
+      { name: 'oat milk', qty: '2', unit: 'tbsp' },
+      { name: 'vanilla extract', qty: '½', unit: 'tsp' },
+    ],
+  },
+];
+
+/** Render a step and strip it back to "label→popover-text" pairs for easy assertions. */
+function linked(step: string, groups: IngredientGroup[]): Array<[string, string]> {
+  const html = linkIngredientsInHtml(step, buildIngredientIndex(groups), { n: 0 });
+  const out: Array<[string, string]> = [];
+  const re = /<button[^>]*>([^<]*)<\/button><span[^>]*class="ing-pop"[^>]*>(.*?)<\/span><\/span>/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html)) !== null) {
+    out.push([m[1], m[2].replace(/<[^>]+>/g, '').trim()]);
+  }
+  return out;
+}
+
+describe('buildIngredientIndex', () => {
+  it('excludes items with no measurement', () => {
+    const { lookup } = buildIngredientIndex(cookies);
+    expect(lookup.has('oil spray')).toBe(false);
+    expect(lookup.get('flour')).toEqual([{ measurement: '1 ½ cup', group: undefined }]);
+  });
+
+  it('keeps a count-only measurement (no unit)', () => {
+    const { lookup } = buildIngredientIndex(cookies);
+    expect(lookup.get('egg')).toEqual([{ measurement: '1', group: undefined }]);
+  });
+
+  it('collects every measurement for a name repeated across groups', () => {
+    const { lookup } = buildIngredientIndex(appleBread);
+    expect(lookup.get('vanilla extract')).toEqual([
+      { measurement: '1 ½ tsp', group: 'Bread layer' },
+      { measurement: '½ tsp', group: 'Icing' },
+    ]);
+    expect(lookup.get('oat milk')).toHaveLength(2);
+  });
+});
+
+describe('linkIngredientsInHtml — matching', () => {
+  it('matches a plain single-word name', () => {
+    expect(linked('mix the flour well', cookies)).toEqual([['flour', '1 ½ cup']]);
+  });
+
+  it('prefers the longest name (brown sugar, not sugar)', () => {
+    const hits = linked('add brown sugar and white sugar', cookies);
+    expect(hits).toEqual([
+      ['brown sugar', '½ cup'],
+      ['white sugar', '6 tbsp'],
+    ]);
+  });
+
+  it('does not match a plain "sugar" mention as brown/white sugar', () => {
+    // apple-bread has a standalone "sugar" ingredient.
+    expect(linked('cream the butter and sugar', appleBread)).toEqual([
+      ['butter', '8 tbsp'], // matched via prep-stripped alias of "softened butter"
+      ['sugar', '⅔ cup'],
+    ]);
+  });
+
+  it('matches through a leading prep adjective (medium apples → apples)', () => {
+    expect(linked('peel the apples', appleBread)).toEqual([['apples', '2']]);
+  });
+
+  it('matches a prose singular against a plural-stored name (apple → apples)', () => {
+    expect(linked('chop one apple', appleBread)).toEqual([['apple', '2']]);
+  });
+
+  it('is case-insensitive', () => {
+    expect(linked('Add the Flour', cookies)).toEqual([['Flour', '1 ½ cup']]);
+  });
+
+  it('respects word boundaries (no match inside "salted")', () => {
+    const salt: IngredientGroup[] = [{ items: [{ name: 'salt', qty: '½', unit: 'tsp' }] }];
+    expect(linked('use salted butter', salt)).toEqual([]);
+  });
+
+  it('renders an ambiguous name as rows with group labels', () => {
+    const html = linkIngredientsInHtml('stir in the oat milk', buildIngredientIndex(appleBread), { n: 0 });
+    expect(html).toContain('½ cup <span class="ing-pop-group">· Bread layer</span>');
+    expect(html).toContain('2 tbsp <span class="ing-pop-group">· Icing</span>');
+  });
+
+  it('wraps every occurrence with a unique id', () => {
+    const html = linkIngredientsInHtml('flour, then more flour', buildIngredientIndex(cookies), { n: 0 });
+    expect(html).toContain('id="ing-pop-0"');
+    expect(html).toContain('id="ing-pop-1"');
+  });
+});
+
+describe('linkIngredientsInHtml — HTML safety', () => {
+  const idx = () => buildIngredientIndex(cookies);
+
+  it('leaves markdown tags intact and still matches text inside them', () => {
+    const html = linkIngredientsInHtml('mix the <strong>flour</strong>', idx(), { n: 0 });
+    expect(html).toContain('<strong>');
+    expect(html).toContain('</strong>');
+    expect(html).toContain('class="ing-ref"');
+  });
+
+  it('does not wrap text inside a link', () => {
+    const html = linkIngredientsInHtml('<a href="/x">flour</a>', idx(), { n: 0 });
+    expect(html).toBe('<a href="/x">flour</a>');
+  });
+
+  it('does not wrap text inside code', () => {
+    const html = linkIngredientsInHtml('<code>flour</code>', idx(), { n: 0 });
+    expect(html).toBe('<code>flour</code>');
+  });
+
+  it('leaves entities untouched', () => {
+    const html = linkIngredientsInHtml('350&deg; then flour', idx(), { n: 0 });
+    expect(html).toContain('350&deg;');
+    expect(html).toContain('class="ing-ref"');
+  });
+
+  it('returns the html unchanged when nothing is indexable', () => {
+    const empty = buildIngredientIndex([{ items: [{ name: 'Oil spray' }] }]);
+    expect(linkIngredientsInHtml('spray the pan', empty)).toBe('spray the pan');
+  });
+});

--- a/src/lib/ingredients.ts
+++ b/src/lib/ingredients.ts
@@ -1,0 +1,225 @@
+/**
+ * Ingredient ↔ step linking. Recipe ingredients are structured `{ name, qty?, unit? }`
+ * (see content.config.ts); steps are free-form prose that name those ingredients. This
+ * module builds a name→measurement index from a recipe's ingredients and rewrites step
+ * HTML so each ingredient mention becomes a hover/tap target showing its measurement.
+ *
+ * All logic is pure and build-time (Astro SSG) — no client parsing. The only runtime cost
+ * is the small popover script; the measurement text is baked into the HTML.
+ */
+
+export interface StructuredItem {
+  name: string;
+  qty?: string;
+  unit?: string;
+}
+
+export interface IngredientGroup {
+  group?: string;
+  items: StructuredItem[];
+}
+
+/** One place an ingredient name is measured — its amount and the group it belongs to. */
+interface Occurrence {
+  measurement: string;
+  group?: string;
+}
+
+export interface IngredientIndex {
+  /** Canonical name (prep-clause-stripped, lowercased) → every measurement it has. */
+  lookup: Map<string, Occurrence[]>;
+  /** Any matchable surface form (incl. plural/alias) → its canonical lookup key. */
+  formToKey: Map<string, string>;
+  /** Combined matcher over all surface forms, or null when nothing is indexable. */
+  regex: RegExp | null;
+}
+
+/**
+ * Leading words that describe *preparation* and are routinely dropped in step prose
+ * ("softened butter" → "butter", "medium apples" → "apples"). Deliberately excludes
+ * type/colour qualifiers ("brown", "white", "powdered", "dark") — those distinguish one
+ * ingredient from another ("brown sugar" ≠ "sugar") and must NOT be stripped.
+ */
+const PREP_ADJECTIVES = new Set([
+  'softened', 'melted', 'chopped', 'finely', 'coarsely', 'ground', 'packed', 'sifted',
+  'diced', 'minced', 'shredded', 'grated', 'peeled', 'beaten', 'crushed', 'toasted',
+  'sliced', 'halved', 'quartered', 'cubed', 'drained', 'rinsed', 'trimmed', 'thinly',
+  'roughly', 'small', 'medium', 'large', 'ripe', 'cold', 'warm', 'boneless', 'skinless',
+]);
+
+const escapeRegex = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const escapeHtml = (s: string): string =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+/** Collapse whitespace and lowercase — the normal form used for all name comparisons. */
+const norm = (s: string): string => s.toLowerCase().replace(/\s+/g, ' ').trim();
+
+/** Ingredient's US measurement label, e.g. "½ cup", "8 tbsp", or "2" for count items. */
+function measurementLabel(item: StructuredItem): string {
+  return [item.qty, item.unit].map((v) => (v ?? '').trim()).filter(Boolean).join(' ');
+}
+
+/** Drop a trailing prep clause after the first comma: "butter, softened" → "butter". */
+function stripNote(name: string): string {
+  return norm(name.split(',')[0] ?? '');
+}
+
+/** Strip leading prep adjectives: "finely chopped medium apples" → "apples". */
+function stripPrep(name: string): string {
+  const words = name.split(' ');
+  let i = 0;
+  while (i < words.length - 1 && PREP_ADJECTIVES.has(words[i])) i++;
+  return words.slice(i).join(' ');
+}
+
+/** Best-effort singular of an English word ("apples" → "apple", "cherries" → "cherry"). */
+function singularize(word: string): string {
+  if (/ies$/.test(word)) return word.replace(/ies$/, 'y');
+  if (/(ses|xes|zes|ches|shes|oes)$/.test(word)) return word.replace(/es$/, '');
+  if (/ss$/.test(word)) return word;
+  if (/s$/.test(word)) return word.replace(/s$/, '');
+  return word;
+}
+
+/** Best-effort plural of an English word ("apple" → "apples", "cherry" → "cherries"). */
+function pluralize(word: string): string {
+  if (/[^aeiou]y$/.test(word)) return word.replace(/y$/, 'ies');
+  if (/(s|x|z|ch|sh|o)$/.test(word)) return `${word}es`;
+  return `${word}s`;
+}
+
+/**
+ * Surface forms of a phrase to match in prose, varying only the last word's number so an
+ * ingredient stored plural still matches singular usage and vice-versa. "cherry tomatoes"
+ * → ["cherry tomatoes", "cherry tomato"].
+ */
+function phraseForms(phrase: string): string[] {
+  const words = phrase.split(' ');
+  const last = words[words.length - 1];
+  const base = singularize(last);
+  const lastForms = [...new Set([last, base, pluralize(base)])];
+  const head = words.slice(0, -1);
+  return lastForms.map((w) => [...head, w].join(' '));
+}
+
+/**
+ * Build the name→measurement index for one recipe's ingredient groups. Items with no
+ * measurement (e.g. "Oil spray") are skipped — an empty popover is worse than none, and
+ * such items rarely appear verbatim in steps. A name appearing in multiple groups keeps
+ * all its measurements (the ambiguity case), surfaced together in the popover.
+ */
+export function buildIngredientIndex(groups: IngredientGroup[]): IngredientIndex {
+  const lookup = new Map<string, Occurrence[]>();
+
+  for (const g of groups) {
+    for (const item of g.items) {
+      const measurement = measurementLabel(item);
+      if (!measurement) continue;
+      const key = stripNote(item.name);
+      if (!key) continue;
+      const list = lookup.get(key) ?? [];
+      list.push({ measurement, group: g.group });
+      lookup.set(key, list);
+    }
+  }
+
+  const formToKey = new Map<string, string>();
+  const forms = new Set<string>();
+
+  // Full names win over prep-stripped aliases, so register them first and never let an
+  // alias overwrite a real ingredient's own name (protects "sugar" from "brown sugar"'s alias).
+  for (const key of lookup.keys()) {
+    for (const f of phraseForms(key)) {
+      formToKey.set(f, key);
+      forms.add(f);
+    }
+  }
+  for (const key of lookup.keys()) {
+    const alias = stripPrep(key);
+    if (!alias || alias === key) continue;
+    for (const f of phraseForms(alias)) {
+      if (formToKey.has(f)) continue;
+      formToKey.set(f, key);
+      forms.add(f);
+    }
+  }
+
+  return { lookup, formToKey, regex: buildRegex([...forms]) };
+}
+
+/** Combined, word-boundary-anchored, longest-match-first regex over all surface forms. */
+function buildRegex(forms: string[]): RegExp | null {
+  if (forms.length === 0) return null;
+  const alternation = forms
+    .sort((a, b) => b.length - a.length) // longest first → "brown sugar" beats "sugar"
+    .map((form) => form.split(' ').map(escapeRegex).join('\\s+'))
+    .join('|');
+  return new RegExp(`\\b(${alternation})\\b`, 'gi');
+}
+
+/** The interactive trigger + measurement popover for one matched ingredient mention. */
+function buildTrigger(label: string, occurrences: Occurrence[], id: number): string {
+  const popId = `ing-pop-${id}`;
+  // A single measurement shows just the amount; the group label only earns its place when
+  // it disambiguates between multiple measurements of the same name.
+  const inner =
+    occurrences.length === 1
+      ? escapeHtml(occurrences[0].measurement)
+      : occurrences
+          .map((o) => {
+            const amount = escapeHtml(o.measurement);
+            const group = o.group
+              ? ` <span class="ing-pop-group">· ${escapeHtml(o.group)}</span>`
+              : '';
+            return `<span class="ing-pop-row">${amount}${group}</span>`;
+          })
+          .join('');
+  return (
+    `<span class="ing-ref">` +
+    `<button type="button" class="ing-ref-btn" aria-expanded="false" aria-describedby="${popId}">${escapeHtml(label)}</button>` +
+    `<span role="tooltip" id="${popId}" class="ing-pop">${inner}</span>` +
+    `</span>`
+  );
+}
+
+/**
+ * Rewrite already-rendered step HTML, wrapping ingredient mentions in popover triggers.
+ *
+ * Runs on the HTML produced by inlineMarkdown (markdown-first): the tokenizer only ever
+ * touches plain-text runs, so it can't corrupt tags or entities, and it skips text inside
+ * <a>/<code> to avoid nesting a button in a link or mangling code. `idState` threads a
+ * per-page counter so every popover gets a unique id across all steps.
+ */
+export function linkIngredientsInHtml(
+  html: string,
+  index: IngredientIndex,
+  idState: { n: number } = { n: 0 }
+): string {
+  const { regex, formToKey, lookup } = index;
+  if (!regex) return html;
+
+  let skipDepth = 0;
+  // Split into tags, entities, and the text between them; odd matches are tags/entities.
+  return html
+    .split(/(<[^>]+>|&[^;\s]+;)/)
+    .map((token) => {
+      if (!token) return token;
+
+      if (token[0] === '<') {
+        if (/^<(a|code)[\s>]/i.test(token)) skipDepth++;
+        else if (/^<\/(a|code)>/i.test(token) && skipDepth > 0) skipDepth--;
+        return token;
+      }
+      if (token[0] === '&') return token; // HTML entity — leave untouched
+      if (skipDepth > 0) return token; // inside <a>/<code>
+
+      return token.replace(regex, (match) => {
+        const key = formToKey.get(norm(match));
+        const occurrences = key ? lookup.get(key) : undefined;
+        if (!occurrences || occurrences.length === 0) return match;
+        return buildTrigger(match, occurrences, idState.n++);
+      });
+    })
+    .join('');
+}

--- a/src/lib/ingredients.ts
+++ b/src/lib/ingredients.ts
@@ -2,10 +2,20 @@
  * Ingredient ↔ step linking. Recipe ingredients are structured `{ name, qty?, unit? }`
  * (see content.config.ts); steps are free-form prose that name those ingredients. This
  * module builds a name→measurement index from a recipe's ingredients and rewrites step
- * HTML so each ingredient mention becomes a hover/tap target showing its measurement.
+ * HTML so each ingredient mention becomes a bold hover/tap target showing its measurement.
  *
- * All logic is pure and build-time (Astro SSG) — no client parsing. The only runtime cost
- * is the small popover script; the measurement text is baked into the HTML.
+ * Matching is lexical and works from the ingredient's stored name, which is often more
+ * qualified than the step prose ("granulated sugar" vs "sugar", "vanilla bean paste" vs
+ * "vanilla"). To bridge that gap each ingredient registers several surface forms:
+ *   - the full name (specific);
+ *   - every trailing suffix / "head noun" ("vegetable oil" → "oil") (generic);
+ *   - the name with leading qualifiers or a trailing descriptor stripped
+ *     ("vanilla bean paste" → "vanilla", "unsalted butter" → "butter") (generic).
+ * When a prose word matches, a *specific* (full-name) match always wins over *generic*
+ * aliases — so a recipe with a plain "sugar" resolves "sugar" to that, while a recipe with
+ * only "granulated sugar" + "powdered sugar" resolves "sugar" to both (shown with labels).
+ *
+ * All logic is pure and build-time (Astro SSG) — no client parsing.
  */
 
 export interface StructuredItem {
@@ -19,32 +29,50 @@ export interface IngredientGroup {
   items: StructuredItem[];
 }
 
-/** One place an ingredient name is measured — its amount and the group it belongs to. */
-interface Occurrence {
-  measurement: string;
+/** One measured occurrence of an ingredient — its name, US + grams amounts, and group. */
+interface Entry {
+  name: string;
+  us: string;
+  grams: string | null;
   group?: string;
 }
 
+/** Entries reachable by a surface form, split by how precisely they matched it. */
+interface FormEntries {
+  specific: Entry[];
+  generic: Entry[];
+}
+
 export interface IngredientIndex {
-  /** Canonical name (prep-clause-stripped, lowercased) → every measurement it has. */
-  lookup: Map<string, Occurrence[]>;
-  /** Any matchable surface form (incl. plural/alias) → its canonical lookup key. */
-  formToKey: Map<string, string>;
-  /** Combined matcher over all surface forms, or null when nothing is indexable. */
+  /** Surface form → the entries it resolves to, by specificity. */
+  forms: Map<string, FormEntries>;
+  /** Combined, longest-match-first matcher over all forms, or null when nothing indexable. */
   regex: RegExp | null;
 }
 
 /**
- * Leading words that describe *preparation* and are routinely dropped in step prose
- * ("softened butter" → "butter", "medium apples" → "apples"). Deliberately excludes
- * type/colour qualifiers ("brown", "white", "powdered", "dark") — those distinguish one
- * ingredient from another ("brown sugar" ≠ "sugar") and must NOT be stripped.
+ * Leading words describing preparation or type that step prose routinely drops
+ * ("unsalted butter" → "butter", "granulated sugar" → "sugar"). Stripping these only ever
+ * produces a *generic* alias, so it never overrides a real ingredient of the bare name.
  */
-const PREP_ADJECTIVES = new Set([
+const LEADING_STRIP = new Set([
+  // preparation
   'softened', 'melted', 'chopped', 'finely', 'coarsely', 'ground', 'packed', 'sifted',
   'diced', 'minced', 'shredded', 'grated', 'peeled', 'beaten', 'crushed', 'toasted',
   'sliced', 'halved', 'quartered', 'cubed', 'drained', 'rinsed', 'trimmed', 'thinly',
-  'roughly', 'small', 'medium', 'large', 'ripe', 'cold', 'warm', 'boneless', 'skinless',
+  'roughly', 'ripe', 'cold', 'warm', 'hot', 'boneless', 'skinless',
+  // size / type qualifiers dropped in prose
+  'small', 'medium', 'large', 'unsalted', 'salted', 'vegetable', 'granulated', 'greek',
+  'loose', 'fresh', 'dried', 'whole', 'light', 'dark', 'heavy', 'all', 'purpose',
+]);
+
+/** Trailing descriptors to peel so a front-distinctive name yields its everyday alias. */
+const TRAILING_FORMS = ['bean paste', 'tea leaves', 'paste', 'extract', 'leaves', 'puree'];
+
+/** Too-generic surface forms to never register as match targets. */
+const STOP_FORMS = new Set([
+  'paste', 'extract', 'leaves', 'grey', 'bean', 'ingredient', 'ingredients', 'temp',
+  'purpose', 'powder', 'soda', 'water',
 ]);
 
 const escapeRegex = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -55,25 +83,43 @@ const escapeHtml = (s: string): string =>
 /** Collapse whitespace and lowercase — the normal form used for all name comparisons. */
 const norm = (s: string): string => s.toLowerCase().replace(/\s+/g, ' ').trim();
 
-/** Ingredient's US measurement label, e.g. "½ cup", "8 tbsp", or "2" for count items. */
+/** Ingredient's US measurement label, e.g. "½ cup", "8 tbsp", or "4" for count items. */
 function measurementLabel(item: StructuredItem): string {
   return [item.qty, item.unit].map((v) => (v ?? '').trim()).filter(Boolean).join(' ');
 }
 
-/** Drop a trailing prep clause after the first comma: "butter, softened" → "butter". */
-function stripNote(name: string): string {
-  return norm(name.split(',')[0] ?? '');
+/** Canonical ingredient name: drop a parenthetical, a comma-note, and normalise. */
+function cleanName(name: string): string {
+  const noParen = name.replace(/\([^)]*\)/g, ' ');
+  return norm((noParen.split(',')[0] ?? '').trim());
 }
 
-/** Strip leading prep adjectives: "finely chopped medium apples" → "apples". */
-function stripPrep(name: string): string {
+/** Remove leading qualifier words (keeps at least the final word). */
+function stripLeading(name: string): string {
   const words = name.split(' ');
   let i = 0;
-  while (i < words.length - 1 && PREP_ADJECTIVES.has(words[i])) i++;
+  while (i < words.length - 1 && LEADING_STRIP.has(words[i])) i++;
   return words.slice(i).join(' ');
 }
 
-/** Best-effort singular of an English word ("apples" → "apple", "cherries" → "cherry"). */
+/** Peel trailing descriptor words: "vanilla bean paste" → "vanilla". */
+function stripTrailing(name: string): string {
+  let out = name;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const tail of TRAILING_FORMS) {
+      if (out === tail) return '';
+      if (out.endsWith(` ${tail}`)) {
+        out = out.slice(0, -tail.length - 1).trim();
+        changed = true;
+        break;
+      }
+    }
+  }
+  return out;
+}
+
 function singularize(word: string): string {
   if (/ies$/.test(word)) return word.replace(/ies$/, 'y');
   if (/(ses|xes|zes|ches|shes|oes)$/.test(word)) return word.replace(/es$/, '');
@@ -82,98 +128,126 @@ function singularize(word: string): string {
   return word;
 }
 
-/** Best-effort plural of an English word ("apple" → "apples", "cherry" → "cherries"). */
 function pluralize(word: string): string {
   if (/[^aeiou]y$/.test(word)) return word.replace(/y$/, 'ies');
   if (/(s|x|z|ch|sh|o)$/.test(word)) return `${word}es`;
   return `${word}s`;
 }
 
-/**
- * Surface forms of a phrase to match in prose, varying only the last word's number so an
- * ingredient stored plural still matches singular usage and vice-versa. "cherry tomatoes"
- * → ["cherry tomatoes", "cherry tomato"].
- */
+/** A phrase plus singular/plural variants of its last word, for both-way number matching. */
 function phraseForms(phrase: string): string[] {
   const words = phrase.split(' ');
   const last = words[words.length - 1];
   const base = singularize(last);
-  const lastForms = [...new Set([last, base, pluralize(base)])];
+  const variants = [...new Set([last, base, pluralize(base)])];
   const head = words.slice(0, -1);
-  return lastForms.map((w) => [...head, w].join(' '));
+  return variants.map((w) => [...head, w].join(' '));
+}
+
+/** Generic alias phrases for a canonical name: head nouns + leading/trailing-stripped forms. */
+function genericAliases(canonical: string): Set<string> {
+  const out = new Set<string>();
+  const words = canonical.split(' ');
+  for (let i = 1; i < words.length; i++) out.add(words.slice(i).join(' ')); // head-noun suffixes
+
+  const lead = stripLeading(canonical);
+  if (lead && lead !== canonical) out.add(lead);
+
+  const pre = stripTrailing(canonical);
+  if (pre && pre !== canonical) {
+    out.add(pre);
+    const preLead = stripLeading(pre);
+    if (preLead) out.add(preLead);
+  }
+  return out;
 }
 
 /**
- * Build the name→measurement index for one recipe's ingredient groups. Items with no
- * measurement (e.g. "Oil spray") are skipped — an empty popover is worse than none, and
- * such items rarely appear verbatim in steps. A name appearing in multiple groups keeps
- * all its measurements (the ambiguity case), surfaced together in the popover.
+ * Build the surface-form index for one recipe's ingredient groups. Items with no
+ * measurement (e.g. "Oil spray") are skipped. A name appearing in multiple groups — or
+ * several qualified names sharing one generic alias — surfaces all their measurements.
  */
-export function buildIngredientIndex(groups: IngredientGroup[]): IngredientIndex {
-  const lookup = new Map<string, Occurrence[]>();
+export function buildIngredientIndex(
+  groups: IngredientGroup[],
+  gramsOf?: (item: StructuredItem) => string | null
+): IngredientIndex {
+  const forms = new Map<string, FormEntries>();
+
+  const add = (form: string, entry: Entry, specific: boolean) => {
+    const key = norm(form);
+    if (key.length < 2 || STOP_FORMS.has(key)) return;
+    const rec = forms.get(key) ?? { specific: [], generic: [] };
+    (specific ? rec.specific : rec.generic).push(entry);
+    forms.set(key, rec);
+  };
 
   for (const g of groups) {
     for (const item of g.items) {
-      const measurement = measurementLabel(item);
-      if (!measurement) continue;
-      const key = stripNote(item.name);
-      if (!key) continue;
-      const list = lookup.get(key) ?? [];
-      list.push({ measurement, group: g.group });
-      lookup.set(key, list);
+      const us = measurementLabel(item);
+      if (!us) continue;
+      const canonical = cleanName(item.name);
+      if (!canonical) continue;
+      const grams = gramsOf ? gramsOf(item) : null;
+      const entry: Entry = { name: canonical, us, grams, group: g.group };
+
+      for (const f of phraseForms(canonical)) add(f, entry, true);
+      for (const alias of genericAliases(canonical)) {
+        for (const f of phraseForms(alias)) add(f, entry, false);
+      }
     }
   }
 
-  const formToKey = new Map<string, string>();
-  const forms = new Set<string>();
-
-  // Full names win over prep-stripped aliases, so register them first and never let an
-  // alias overwrite a real ingredient's own name (protects "sugar" from "brown sugar"'s alias).
-  for (const key of lookup.keys()) {
-    for (const f of phraseForms(key)) {
-      formToKey.set(f, key);
-      forms.add(f);
-    }
-  }
-  for (const key of lookup.keys()) {
-    const alias = stripPrep(key);
-    if (!alias || alias === key) continue;
-    for (const f of phraseForms(alias)) {
-      if (formToKey.has(f)) continue;
-      formToKey.set(f, key);
-      forms.add(f);
-    }
-  }
-
-  return { lookup, formToKey, regex: buildRegex([...forms]) };
+  return { forms, regex: buildRegex([...forms.keys()]) };
 }
 
 /** Combined, word-boundary-anchored, longest-match-first regex over all surface forms. */
 function buildRegex(forms: string[]): RegExp | null {
   if (forms.length === 0) return null;
   const alternation = forms
-    .sort((a, b) => b.length - a.length) // longest first → "brown sugar" beats "sugar"
+    .sort((a, b) => b.length - a.length) // longest first → "granulated sugar" beats "sugar"
     .map((form) => form.split(' ').map(escapeRegex).join('\\s+'))
     .join('|');
   return new RegExp(`\\b(${alternation})\\b`, 'gi');
 }
 
+/** Resolve a matched surface form to its entries: a specific (full-name) hit wins over aliases. */
+function resolve(index: IngredientIndex, matched: string): Entry[] {
+  const rec = index.forms.get(norm(matched));
+  if (!rec) return [];
+  const chosen = rec.specific.length > 0 ? rec.specific : rec.generic;
+  const seen = new Set<string>();
+  return chosen.filter((e) => {
+    const k = `${e.name}|${e.us}|${e.grams ?? ''}|${e.group ?? ''}`;
+    if (seen.has(k)) return false;
+    seen.add(k);
+    return true;
+  });
+}
+
+/**
+ * The amount cell for one entry. Carries both US and (when known) grams text; which one
+ * shows is driven by the page's `data-units` mode via CSS. A cell with a grams equivalent is
+ * marked `.ing-conv` so grams mode can hide only its US text (count/unknown items stay US).
+ */
+function amountHtml(e: Entry): string {
+  const us = `<span class="ing-us">${escapeHtml(e.us)}</span>`;
+  const grams = e.grams ? `<span class="ing-grams">${escapeHtml(e.grams)}</span>` : '';
+  return `<span class="ing-amt${e.grams ? ' ing-conv' : ''}">${us}${grams}</span>`;
+}
+
 /** The interactive trigger + measurement popover for one matched ingredient mention. */
-function buildTrigger(label: string, occurrences: Occurrence[], id: number): string {
+function buildTrigger(label: string, entries: Entry[], id: number): string {
   const popId = `ing-pop-${id}`;
-  // A single measurement shows just the amount; the group label only earns its place when
-  // it disambiguates between multiple measurements of the same name.
+  // A single measurement shows just the amount; group labels only earn their place when
+  // they disambiguate between multiple measurements of the same mention.
   const inner =
-    occurrences.length === 1
-      ? escapeHtml(occurrences[0].measurement)
-      : occurrences
-          .map((o) => {
-            const amount = escapeHtml(o.measurement);
-            const group = o.group
-              ? ` <span class="ing-pop-group">· ${escapeHtml(o.group)}</span>`
-              : '';
-            return `<span class="ing-pop-row">${amount}${group}</span>`;
-          })
+    entries.length === 1
+      ? amountHtml(entries[0])
+      : entries
+          .map(
+            (e) =>
+              `<span class="ing-pop-row">${amountHtml(e)} <span class="ing-pop-group">· ${escapeHtml(e.group ?? e.name)}</span></span>`
+          )
           .join('');
   return (
     `<span class="ing-ref">` +
@@ -196,7 +270,7 @@ export function linkIngredientsInHtml(
   index: IngredientIndex,
   idState: { n: number } = { n: 0 }
 ): string {
-  const { regex, formToKey, lookup } = index;
+  const { regex } = index;
   if (!regex) return html;
 
   let skipDepth = 0;
@@ -215,10 +289,9 @@ export function linkIngredientsInHtml(
       if (skipDepth > 0) return token; // inside <a>/<code>
 
       return token.replace(regex, (match) => {
-        const key = formToKey.get(norm(match));
-        const occurrences = key ? lookup.get(key) : undefined;
-        if (!occurrences || occurrences.length === 0) return match;
-        return buildTrigger(match, occurrences, idState.n++);
+        const entries = resolve(index, match);
+        if (entries.length === 0) return match;
+        return buildTrigger(match, entries, idState.n++);
       });
     })
     .join('');

--- a/src/lib/units.ts
+++ b/src/lib/units.ts
@@ -121,6 +121,30 @@ export function parseQty(qty: string | number | undefined | null): number | null
 }
 
 /**
+ * Look up an ingredient's grams-per-cup density by name, tolerating qualifiers the density
+ * list doesn't spell out. Tries the cleaned full name first (so a qualifier that changes the
+ * density — "powdered sugar" 120 vs "sugar" 200 — still wins), then progressively drops
+ * leading words ("unsalted butter" → "butter", "Greek yogurt" → "yogurt"). Returns null when
+ * nothing matches.
+ */
+export function lookupDensity(name: string | undefined | null, densities: Densities): number | null {
+  const clean = String(name ?? '')
+    .toLowerCase()
+    .replace(/\([^)]*\)/g, ' ')
+    .split(',')[0]
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!clean) return null;
+
+  const words = clean.split(' ');
+  for (let i = 0; i < words.length; i++) {
+    const candidate = words.slice(i).join(' ');
+    if (densities?.[candidate] != null) return densities[candidate];
+  }
+  return null;
+}
+
+/**
  * Convert (qty, unit, name) to grams, or null if it can't be converted:
  *   - weight unit  → qty × fixed factor (density irrelevant);
  *   - volume unit  → qty × cups-per-unit × density[name] (needs a known density);
@@ -141,7 +165,7 @@ export function toGrams(
   }
 
   if (u in VOLUME_IN_CUPS) {
-    const density = densities?.[String(name ?? '').toLowerCase().trim()];
+    const density = lookupDensity(name, densities);
     if (density == null) return null;
     const n = parseQty(qty);
     return n == null ? null : n * VOLUME_IN_CUPS[u] * density;

--- a/src/scripts/ingredient-popover.test.ts
+++ b/src/scripts/ingredient-popover.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { initIngredientPopovers } from './ingredient-popover';
+
+/** Build the same trigger markup lib/ingredients.ts injects into step HTML. */
+function trigger(id: number, label: string): string {
+  return (
+    `<span class="ing-ref">` +
+    `<button type="button" class="ing-ref-btn" aria-expanded="false" aria-describedby="ing-pop-${id}">${label}</button>` +
+    `<span role="tooltip" id="ing-pop-${id}" class="ing-pop">stuff</span>` +
+    `</span>`
+  );
+}
+
+function setup(...labels: string[]) {
+  document.body.innerHTML =
+    labels.map((l, i) => trigger(i, l)).join(' and ') + '<p id="outside">elsewhere</p>';
+  initIngredientPopovers();
+  const refs = Array.from(document.querySelectorAll<HTMLElement>('.ing-ref'));
+  const btns = refs.map((r) => r.querySelector<HTMLButtonElement>('.ing-ref-btn')!);
+  return { refs, btns };
+}
+
+const isOpen = (ref: HTMLElement) => ref.hasAttribute('data-open');
+
+describe('initIngredientPopovers', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('opens on click and reflects state in aria-expanded', () => {
+    const { refs, btns } = setup('flour');
+    expect(isOpen(refs[0])).toBe(false);
+
+    btns[0].click();
+    expect(isOpen(refs[0])).toBe(true);
+    expect(btns[0].getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('toggles closed on a second click', () => {
+    const { refs, btns } = setup('flour');
+    btns[0].click();
+    btns[0].click();
+    expect(isOpen(refs[0])).toBe(false);
+    expect(btns[0].getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('opening one popover closes any other', () => {
+    const { refs, btns } = setup('flour', 'sugar');
+    btns[0].click();
+    expect(isOpen(refs[0])).toBe(true);
+
+    btns[1].click();
+    expect(isOpen(refs[1])).toBe(true);
+    expect(isOpen(refs[0])).toBe(false); // first auto-closed
+  });
+
+  it('closes when clicking outside any trigger', () => {
+    const { refs, btns } = setup('flour');
+    btns[0].click();
+    expect(isOpen(refs[0])).toBe(true);
+
+    document.getElementById('outside')!.click();
+    expect(isOpen(refs[0])).toBe(false);
+  });
+
+  it('Escape closes the open popover and returns focus to its button', () => {
+    const { refs, btns } = setup('flour');
+    btns[0].click();
+    expect(isOpen(refs[0])).toBe(true);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(isOpen(refs[0])).toBe(false);
+    expect(document.activeElement).toBe(btns[0]);
+  });
+
+  it('is a no-op when there are no triggers', () => {
+    document.body.innerHTML = '<p>nothing here</p>';
+    expect(() => initIngredientPopovers()).not.toThrow();
+  });
+});

--- a/src/scripts/ingredient-popover.ts
+++ b/src/scripts/ingredient-popover.ts
@@ -1,0 +1,44 @@
+/**
+ * Ingredient measurement popovers in recipe steps. The triggers and their measurement
+ * panels are baked into the step HTML at build time (see lib/ingredients.ts) and reveal on
+ * hover / keyboard focus via pure CSS. This module only adds what CSS can't: tap-to-toggle
+ * for touch devices, and dismissal via Escape or an outside click. If it never runs (JS
+ * disabled), hover and focus still work.
+ */
+export function initIngredientPopovers(): void {
+  const refs = Array.from(document.querySelectorAll<HTMLElement>('.ing-ref'));
+  if (refs.length === 0) return;
+
+  const closeAll = (except?: HTMLElement) => {
+    for (const ref of refs) {
+      if (ref === except) continue;
+      if (ref.hasAttribute('data-open')) {
+        ref.removeAttribute('data-open');
+        ref.querySelector('.ing-ref-btn')?.setAttribute('aria-expanded', 'false');
+      }
+    }
+  };
+
+  for (const ref of refs) {
+    const btn = ref.querySelector<HTMLButtonElement>('.ing-ref-btn');
+    if (!btn) continue;
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      const open = ref.toggleAttribute('data-open');
+      btn.setAttribute('aria-expanded', String(open));
+      if (open) closeAll(ref);
+    });
+  }
+
+  document.addEventListener('click', (e) => {
+    if (!(e.target instanceof Element) || !e.target.closest('.ing-ref')) closeAll();
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key !== 'Escape') return;
+    const open = refs.find((ref) => ref.hasAttribute('data-open'));
+    if (!open) return;
+    closeAll();
+    open.querySelector<HTMLButtonElement>('.ing-ref-btn')?.focus();
+  });
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -36,6 +36,7 @@ body {
 
 .ing-ref-btn {
   font: inherit;
+  font-weight: 600; /* all matched ingredients read bold in the steps */
   color: inherit;
   background: none;
   border: none;
@@ -81,6 +82,20 @@ body {
 /* One row per group when an ingredient is measured in more than one place. */
 .ing-pop-row {
   display: block;
+}
+
+/* US ↔ grams inside the popover, driven by the same toggle as the ingredient list (which
+   sets data-units on <html>). Grams text is hidden until grams mode; in grams mode the US
+   text hides only on convertible amounts, so count/unknown items keep showing their US text.
+   Before the toggle script runs, no data-units is set → the default US view shows. */
+.ing-grams {
+  display: none;
+}
+:root[data-units='grams'] .ing-conv .ing-us {
+  display: none;
+}
+:root[data-units='grams'] .ing-conv .ing-grams {
+  display: inline;
 }
 
 .ing-pop-group {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -23,3 +23,86 @@ body {
 :root:not([data-auth="out"]) .auth-when-out {
   display: none;
 }
+
+/* Ingredient-measurement popovers in recipe steps. Triggers + panels are injected into the
+   step HTML at build time (src/lib/ingredients.ts), so these styles live here (global) rather
+   than in the layout's scoped <style>, which wouldn't reach set:html content. The panel is
+   position:absolute → no layout shift; it reveals on hover, keyboard focus, or the [data-open]
+   set by the tap-toggle script (src/scripts/ingredient-popover.ts). */
+.ing-ref {
+  position: relative;
+  display: inline;
+}
+
+.ing-ref-btn {
+  font: inherit;
+  color: inherit;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: help;
+  border-bottom: 1px dashed var(--color-accent-600);
+}
+
+.ing-ref-btn:hover,
+.ing-ref-btn:focus-visible {
+  color: var(--color-accent-700);
+}
+
+.ing-pop {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  z-index: 20;
+  display: none;
+  min-width: max-content;
+  max-width: 16rem;
+  padding: 0.375rem 0.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid #e5e5e5; /* neutral-200 */
+  background: #ffffff;
+  color: #404040; /* neutral-700 */
+  font-size: 0.75rem;
+  line-height: 1.1rem;
+  font-weight: 500;
+  text-align: left;
+  white-space: nowrap;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 0.1);
+  cursor: default;
+}
+
+.ing-ref:hover > .ing-pop,
+.ing-ref:focus-within > .ing-pop,
+.ing-ref[data-open] > .ing-pop {
+  display: block;
+}
+
+/* One row per group when an ingredient is measured in more than one place. */
+.ing-pop-row {
+  display: block;
+}
+
+.ing-pop-group {
+  color: #737373; /* neutral-500 */
+  font-weight: 400;
+}
+
+@media (prefers-color-scheme: dark) {
+  .ing-ref-btn {
+    border-bottom-color: var(--color-accent-100);
+  }
+  .ing-ref-btn:hover,
+  .ing-ref-btn:focus-visible {
+    color: var(--color-accent-100);
+  }
+  .ing-pop {
+    border-color: #404040; /* neutral-700 */
+    background: #262626; /* neutral-800 */
+    color: #e5e5e5; /* neutral-200 */
+    box-shadow: 0 4px 12px rgb(0 0 0 / 0.4);
+  }
+  .ing-pop-group {
+    color: #a3a3a3; /* neutral-400 */
+  }
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -85,16 +85,17 @@ body {
 }
 
 /* US ↔ grams inside the popover, driven by the same toggle as the ingredient list (which
-   sets data-units on <html>). Grams text is hidden until grams mode; in grams mode the US
-   text hides only on convertible amounts, so count/unknown items keep showing their US text.
-   Before the toggle script runs, no data-units is set → the default US view shows. */
-.ing-grams {
+   sets data-units on <html>). Scoped to `.ing-pop` so it never touches the ingredient
+   list, which has its own (scoped) us/grams rules. Grams text is hidden until grams mode;
+   in grams mode the US text hides only on convertible amounts, so count/unknown items keep
+   showing US. Before the toggle script runs, no data-units is set → the default US view. */
+.ing-pop .ing-grams {
   display: none;
 }
-:root[data-units='grams'] .ing-conv .ing-us {
+:root[data-units='grams'] .ing-pop .ing-conv .ing-us {
   display: none;
 }
-:root[data-units='grams'] .ing-conv .ing-grams {
+:root[data-units='grams'] .ing-pop .ing-conv .ing-grams {
   display: inline;
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## What's the vibe

Ingredient names mentioned in a recipe's **steps** are now hover/tap targets — hover (desktop) or tap (mobile) any ingredient in a step to see its measurement in a little popover. No more scroll-back-up-to-the-ingredients-list energy while you're mid-bake.

Builds directly on the structured `{name, qty?, unit?}` ingredient shape from #19, so no schema change or content migration was needed.

## How it works

- **`src/lib/ingredients.ts`** — build-time, pure, fully tested. Builds a `name → [{measurement, group}]` index from a recipe's ingredients, then rewrites each step's HTML to wrap ingredient mentions in a popover trigger.
  - Longest-match-first (`brown sugar` beats plain `sugar`), case-insensitive, word-boundary safe (won't light up `salt` inside `salted`).
  - Singular/plural both directions (`apple` ↔ `apples`).
  - Strips leading prep adjectives so `softened butter` / `medium apples` still match `butter` / `apples`, while keeping type qualifiers (`brown`/`powdered`) distinct.
  - **Ambiguity handling:** a name measured differently across groups (e.g. `vanilla extract` = 1½ tsp in Bread layer, ½ tsp in Icing) shows **all** measurements with group labels.
  - Runs on post-markdown HTML, skipping `<a>`/`<code>` and entities so it never corrupts tags.
- **`RecipeLayout.astro`** — indexes the recipe, links each step, loads the popover script.
- **`src/scripts/ingredient-popover.ts`** — hover/focus reveal is pure CSS; this only adds tap-toggle, `Escape`, and outside-click dismissal. Degrades gracefully if JS is off.
- **`global.css`** — accent dashed underline + card popover, with dark-mode variants.

## Testing

- ✅ `npm test` — 17 Vitest unit tests (index, matching, longest-match, plurals, prep-alias, ambiguity rows, HTML/tag/entity safety).
- ✅ `npm run build` — all 18 recipes + 25 pages build clean; inspected generated HTML for `apple-bread` (duplicates → both amounts with labels) and `chocochip-cookies` (longest-match).
- ✅ `astro check` clean for the changed files (one pre-existing unrelated `KVNamespace` error in `worker/`).
- ⚠️ Live browser hover/click/keyboard/dark-mode not automated (no browser tooling in this env) — verified the CSS reveal selectors and toggle/Escape script are bundled and referenced by the recipe page. **Worth a quick manual eyeball before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)