### PR TITLE
feat: home cafe ordering — /order + live kitchen board, ordermaxxing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,10 @@ jobs:
           # repo Settings → Secrets and variables → Actions → Variables as PUBLIC_RECIPE_API,
           # e.g. https://izzy-recipe-api.<subdomain>.workers.dev
           PUBLIC_RECIPE_API: ${{ vars.PUBLIC_RECIPE_API }}
+          # Base URL of the Pi order server (via Cloudflare Tunnel), backing /order and /orders.
+          # Set once in repo Settings → Secrets and variables → Actions → Variables as
+          # PUBLIC_ORDER_API, e.g. https://orders.izzybennett.com
+          PUBLIC_ORDER_API: ${{ vars.PUBLIC_ORDER_API }}
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/order-server/.gitignore
+++ b/order-server/.gitignore
@@ -1,0 +1,4 @@
+orders.db
+orders.db-journal
+__pycache__/
+.venv/

--- a/order-server/README.md
+++ b/order-server/README.md
@@ -1,0 +1,117 @@
+# Izzy's Cafe order server
+
+A tiny FastAPI + SQLite server that backs the home-cafe ordering flow:
+
+- **`izzybennett.com/order`** → `POST /orders` (place an order)
+- **`izzybennett.com/orders`** → `GET /orders` (kitchen queue, polled) + `PATCH /orders/{id}` (advance status)
+
+It runs on a **Raspberry Pi** on the home wifi. Because the site is HTTPS on GitHub Pages, the
+browser can't reach a plain-HTTP Pi on the LAN directly, so the Pi exposes this server through a free
+**Cloudflare Tunnel** at a stable public HTTPS hostname (`https://orders.izzybennett.com`). No port
+forwarding, valid TLS, works on and off wifi.
+
+There is **no auth** — anyone with the link can place an order or watch the board (by design for a
+home cafe). CORS is locked to the site origin so only izzybennett.com can call it from a browser.
+
+## API
+
+| Method | Path             | Body                                                    | Notes |
+| ------ | ---------------- | ------------------------------------------------------- | ----- |
+| GET    | `/health`        | —                                                       | `{ "ok": true }` |
+| POST   | `/orders`        | `{ drink, name, milk?, syrups?[], notes? }`             | creates a `new` order (drink + name required) |
+| GET    | `/orders?since=` | —                                                       | active (non-archived) orders, newest first; `since=<id>` for cheap polling |
+| PATCH  | `/orders/{id}`   | `{ status }`                                            | `new` \| `making` \| `done` \| `archived` |
+
+The menu itself is **not** stored here — the order form is built from the site's own
+`/izzys-cafe.json` feed (parsed from `src/content/pages/izzys-cafe.md`), so the menu stays a single
+source of truth.
+
+## Run locally
+
+```sh
+python -m venv .venv
+.venv/bin/pip install -r requirements.txt
+.venv/bin/uvicorn main:app --host 127.0.0.1 --port 8000 --reload
+```
+
+`orders.db` is created next to `main.py` on first run (gitignored).
+
+Smoke test:
+
+```sh
+curl localhost:8000/health
+curl -X POST localhost:8000/orders -H 'content-type: application/json' \
+  -d '{"drink":"Matcha","milk":"Oat","syrups":["Cardamom"],"name":"Izzy"}'
+curl localhost:8000/orders
+curl -X PATCH localhost:8000/orders/1 -H 'content-type: application/json' -d '{"status":"making"}'
+```
+
+To test the site against it: `PUBLIC_ORDER_API=http://localhost:8000 npm run dev` (from the repo root),
+then open `/order` and `/orders`.
+
+## Deploy on the Raspberry Pi
+
+### 1. Run the server as a service
+
+Clone the repo (or copy this `order-server/` dir) to the Pi, create the venv as above, then add a
+systemd unit `/etc/systemd/system/izzy-orders.service`:
+
+```ini
+[Unit]
+Description=Izzy's Cafe order server
+After=network.target
+
+[Service]
+WorkingDirectory=/home/pi/izzybennett.com/order-server
+ExecStart=/home/pi/izzybennett.com/order-server/.venv/bin/uvicorn main:app --host 127.0.0.1 --port 8000
+Restart=always
+User=pi
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```sh
+sudo systemctl enable --now izzy-orders
+curl localhost:8000/health   # should return {"ok":true}
+```
+
+### 2. Expose it with a Cloudflare Tunnel
+
+Requires izzybennett.com's DNS to be on Cloudflare (free; GitHub Pages keeps working via a CNAME).
+
+```sh
+# install cloudflared (see Cloudflare docs for your arch), then:
+cloudflared tunnel login
+cloudflared tunnel create izzy-orders
+cloudflared tunnel route dns izzy-orders orders.izzybennett.com
+```
+
+Config `~/.cloudflared/config.yml`:
+
+```yaml
+tunnel: izzy-orders
+credentials-file: /home/pi/.cloudflared/<tunnel-id>.json
+ingress:
+  - hostname: orders.izzybennett.com
+    service: http://localhost:8000
+  - service: http_status:404
+```
+
+Run it as a service:
+
+```sh
+sudo cloudflared service install
+sudo systemctl enable --now cloudflared
+curl https://orders.izzybennett.com/health   # should return {"ok":true}
+```
+
+### 3. Point the site at it
+
+Set the GitHub Actions repo variable so the build bakes the API base into the site:
+
+**Settings → Secrets and variables → Actions → Variables → New variable**
+`PUBLIC_ORDER_API = https://orders.izzybennett.com`
+
+Then push to `master` (or re-run the deploy workflow) so the site rebuilds against it. `deploy.yml`
+already forwards `PUBLIC_ORDER_API` into the build.

--- a/order-server/main.py
+++ b/order-server/main.py
@@ -1,0 +1,232 @@
+"""Izzy's Cafe order server — runs on the Raspberry Pi.
+
+A tiny FastAPI + SQLite app that backs izzybennett.com/order (place an order) and
+izzybennett.com/orders (the kitchen queue). The static site reaches it over a
+Cloudflare Tunnel at https://orders.izzybennett.com, so CORS is locked to the site
+origin. No auth: anyone with the link can order or watch the board (by design).
+
+Run it:
+    python -m venv .venv && .venv/bin/pip install -r requirements.txt
+    .venv/bin/uvicorn main:app --host 127.0.0.1 --port 8000
+
+The SQLite file lives next to this module and is created on first import.
+"""
+
+import json
+import os
+import sqlite3
+import urllib.error
+import urllib.request
+from contextlib import closing
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi import FastAPI, Header, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
+DB_PATH = Path(__file__).with_name("orders.db")
+
+# Base URL of the OAuth Worker (same one /upload uses). The kitchen open/close toggle is verified
+# against its /api/me endpoint, so only a signed-in GitHub user can flip it. Set RECIPE_API on the
+# Pi to the deployed Worker URL; defaults to the local `wrangler dev` port for development.
+RECIPE_API = os.environ.get("RECIPE_API", "http://localhost:8787").rstrip("/")
+
+# Order lifecycle. "archived" drops a card off the kitchen board (the "Clear done" action)
+# without deleting the row, so the history is still in the DB.
+STATUSES = {"new", "making", "done", "archived"}
+
+# Origins allowed to call this from a browser: the live site plus any localhost port (the `astro dev`
+# server picks whatever port is free — 4321, 4322, …), so the whole flow works end-to-end without the
+# tunnel. Localhost origins are only reachable from this machine, so allowing any port is safe.
+ALLOWED_ORIGINS = ["https://izzybennett.com"]
+ALLOWED_ORIGIN_REGEX = r"http://(localhost|127\.0\.0\.1):\d+"
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def connect() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db() -> None:
+    with closing(connect()) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS orders (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                name       TEXT NOT NULL,
+                drink      TEXT NOT NULL,
+                milk       TEXT,
+                syrups     TEXT NOT NULL DEFAULT '[]',  -- JSON array
+                notes      TEXT,
+                status     TEXT NOT NULL DEFAULT 'new',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+            """
+        )
+        # Small key/value store for app state — currently just whether the kitchen is open.
+        conn.execute("CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+        conn.commit()
+
+
+def get_setting(conn: sqlite3.Connection, key: str, default: str) -> str:
+    row = conn.execute("SELECT value FROM settings WHERE key = ?", (key,)).fetchone()
+    return row["value"] if row else default
+
+
+def set_setting(conn: sqlite3.Connection, key: str, value: str) -> None:
+    conn.execute(
+        "INSERT INTO settings (key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (key, value),
+    )
+
+
+def kitchen_is_open(conn: sqlite3.Connection) -> bool:
+    # Default open, so a fresh DB takes orders without any setup.
+    return get_setting(conn, "kitchen_open", "1") == "1"
+
+
+def verify_session(authorization: str | None) -> bool:
+    """Validate the caller's opaque recipe session against the OAuth Worker's /api/me. A valid
+    session can only belong to the allowed GitHub user, so this is both authn and authz. Fails
+    closed (returns False) if the header is missing or the Worker is unreachable."""
+    if not authorization or not authorization.startswith("Bearer "):
+        return False
+    req = urllib.request.Request(
+        f"{RECIPE_API}/api/me", headers={"Authorization": authorization}, method="GET"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as res:
+            return res.status == 200
+    except (urllib.error.URLError, OSError):
+        return False
+
+
+init_db()
+
+app = FastAPI(title="Izzy's Cafe orders")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_origin_regex=ALLOWED_ORIGIN_REGEX,
+    allow_methods=["GET", "POST", "PATCH", "OPTIONS"],
+    allow_headers=["Content-Type", "Authorization"],
+)
+
+
+class OrderIn(BaseModel):
+    drink: str = Field(min_length=1, max_length=100)
+    name: str = Field(min_length=1, max_length=100)
+    milk: str | None = Field(default=None, max_length=100)
+    syrups: list[str] = Field(default_factory=list)
+    notes: str | None = Field(default=None, max_length=500)
+
+
+class StatusIn(BaseModel):
+    status: str
+
+
+class KitchenIn(BaseModel):
+    open: bool
+
+
+def row_to_order(row: sqlite3.Row) -> dict:
+    order = dict(row)
+    # syrups is stored as a JSON string; hand it back to clients as a real array.
+    order["syrups"] = json.loads(order["syrups"] or "[]")
+    return order
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"ok": True}
+
+
+@app.get("/status")
+def get_status() -> dict:
+    """Whether the kitchen is open. Polled by /order (to show the closed banner) and /orders."""
+    with closing(connect()) as conn:
+        return {"open": kitchen_is_open(conn)}
+
+
+@app.post("/status")
+def set_status(body: KitchenIn, authorization: str | None = Header(default=None)) -> dict:
+    """Open or close the kitchen (the /orders toggle). Requires a valid GitHub sign-in (verified
+    against the OAuth Worker). Closing rejects new orders."""
+    if not verify_session(authorization):
+        raise HTTPException(status_code=401, detail="sign in with GitHub to open or close the kitchen")
+    with closing(connect()) as conn:
+        set_setting(conn, "kitchen_open", "1" if body.open else "0")
+        conn.commit()
+    return {"open": body.open}
+
+
+@app.post("/orders", status_code=201)
+def create_order(order: OrderIn) -> dict:
+    drink = order.drink.strip()
+    if not drink:
+        raise HTTPException(status_code=422, detail="drink is required")
+    name = order.name.strip()
+    if not name:
+        raise HTTPException(status_code=422, detail="name is required")
+
+    ts = now_iso()
+    # Keep only non-empty syrup strings.
+    syrups = [s.strip() for s in order.syrups if s and s.strip()]
+
+    def clean(v: str | None) -> str | None:
+        v = (v or "").strip()
+        return v or None
+
+    with closing(connect()) as conn:
+        # Enforce closed-kitchen server-side, not just in the UI, so a stale page can't sneak an
+        # order in after closing.
+        if not kitchen_is_open(conn):
+            raise HTTPException(status_code=403, detail="kitchen is closed")
+        cur = conn.execute(
+            """
+            INSERT INTO orders (name, drink, milk, syrups, notes, status, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, 'new', ?, ?)
+            """,
+            (name, drink, clean(order.milk), json.dumps(syrups), clean(order.notes), ts, ts),
+        )
+        conn.commit()
+        row = conn.execute("SELECT * FROM orders WHERE id = ?", (cur.lastrowid,)).fetchone()
+    return row_to_order(row)
+
+
+@app.get("/orders")
+def list_orders() -> list[dict]:
+    """Active (non-archived) orders, newest first. The kitchen board rebuilds from the full list
+    each poll, so there's no incremental cursor to maintain."""
+    with closing(connect()) as conn:
+        rows = conn.execute(
+            "SELECT * FROM orders WHERE status != 'archived' ORDER BY id DESC"
+        ).fetchall()
+    return [row_to_order(r) for r in rows]
+
+
+@app.patch("/orders/{order_id}")
+def update_status(order_id: int, body: StatusIn) -> dict:
+    status = body.status.strip()
+    if status not in STATUSES:
+        raise HTTPException(status_code=422, detail=f"status must be one of {sorted(STATUSES)}")
+
+    with closing(connect()) as conn:
+        cur = conn.execute(
+            "UPDATE orders SET status = ?, updated_at = ? WHERE id = ?",
+            (status, now_iso(), order_id),
+        )
+        conn.commit()
+        if cur.rowcount == 0:
+            raise HTTPException(status_code=404, detail="order not found")
+        row = conn.execute("SELECT * FROM orders WHERE id = ?", (order_id,)).fetchone()
+    return row_to_order(row)

--- a/order-server/requirements.txt
+++ b/order-server/requirements.txt
@@ -1,0 +1,2 @@
+fastapi>=0.115
+uvicorn[standard]>=0.30

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -3,6 +3,7 @@ const navLinks = [
   { href: '/recipes/', label: 'Recipes' },
   { href: '/projects/', label: 'Projects' },
   { href: '/izzys-cafe/', label: "Izzy's Cafe" },
+  { href: '/order/', label: 'Order' },
 ];
 
 const currentPath = Astro.url.pathname;

--- a/src/lib/cafe-menu.ts
+++ b/src/lib/cafe-menu.ts
@@ -1,0 +1,45 @@
+// Shared parser for the Izzy's Cafe menu. The markdown body of the `izzys-cafe` page entry is the
+// single source of truth for the menu; this turns it into structured sections consumed by the JSON
+// feed (`/izzys-cafe.json`, for the dizzyos LED-matrix sign) and the order form (`/order`).
+//
+// The markdown is a flat list of sections: a top-level "## Menu" wrapper, then one "####" heading per
+// section (Drinks, Milks, Syrups, Food) followed by "- " list items. Each non-wrapper heading becomes
+// a section and its bullets its items.
+export interface MenuSection {
+  heading: string;
+  items: string[];
+}
+
+export function parseMenu(body: string): MenuSection[] {
+  const sections: MenuSection[] = [];
+  let current: MenuSection | null = null;
+
+  for (const rawLine of body.split('\n')) {
+    const line = rawLine.trim();
+
+    const heading = line.match(/^#{2,6}\s+(.*\S)\s*$/);
+    if (heading) {
+      // "Menu" is just the wrapper heading, not a section of items.
+      if (heading[1].toLowerCase() === 'menu') {
+        current = null;
+        continue;
+      }
+      current = { heading: heading[1], items: [] };
+      sections.push(current);
+      continue;
+    }
+
+    const item = line.match(/^[-*]\s+(.*\S)\s*$/);
+    if (item && current) {
+      current.items.push(item[1]);
+    }
+  }
+
+  return sections.filter((section) => section.items.length > 0);
+}
+
+// Pick a section's items by heading (case-insensitive), or [] if absent.
+export function sectionItems(sections: MenuSection[], heading: string): string[] {
+  const match = sections.find((s) => s.heading.toLowerCase() === heading.toLowerCase());
+  return match ? match.items : [];
+}

--- a/src/pages/izzys-cafe.json.ts
+++ b/src/pages/izzys-cafe.json.ts
@@ -1,47 +1,11 @@
 import type { APIRoute } from 'astro';
 import { getEntry } from 'astro:content';
+import { parseMenu } from '../lib/cafe-menu';
 
 // Build-time JSON feed of the Izzy's Cafe menu, parsed out of the markdown body of the
 // `izzys-cafe` page entry. Consumed by external displays (e.g. the dizzyos LED-matrix sign)
 // so they can render the menu without scraping HTML, keeping the markdown as the single
-// source of truth.
-//
-// The markdown is a flat list of sections: a top-level "## Menu" wrapper, then one "####"
-// heading per section (Drinks, Milks, Additions, Food) followed by "- " list items. We map
-// each non-wrapper heading to a section and collect its bullet items.
-interface MenuSection {
-  heading: string;
-  items: string[];
-}
-
-function parseMenu(body: string): MenuSection[] {
-  const sections: MenuSection[] = [];
-  let current: MenuSection | null = null;
-
-  for (const rawLine of body.split('\n')) {
-    const line = rawLine.trim();
-
-    const heading = line.match(/^#{2,6}\s+(.*\S)\s*$/);
-    if (heading) {
-      // "Menu" is just the wrapper heading, not a section of items.
-      if (heading[1].toLowerCase() === 'menu') {
-        current = null;
-        continue;
-      }
-      current = { heading: heading[1], items: [] };
-      sections.push(current);
-      continue;
-    }
-
-    const item = line.match(/^[-*]\s+(.*\S)\s*$/);
-    if (item && current) {
-      current.items.push(item[1]);
-    }
-  }
-
-  return sections.filter((section) => section.items.length > 0);
-}
-
+// source of truth. The parser is shared with the order form — see src/lib/cafe-menu.ts.
 export const GET: APIRoute = async () => {
   const page = await getEntry('pages', 'izzys-cafe');
   if (!page) throw new Error('Missing "izzys-cafe" entry in the pages collection');

--- a/src/pages/order.astro
+++ b/src/pages/order.astro
@@ -1,0 +1,201 @@
+---
+// Customer ordering page for the home cafe. The menu is built at build time from the same
+// markdown the cafe page + dizzyos sign use (src/content/pages/izzys-cafe.md, via the shared
+// parser), so options never drift from the menu. Submitting POSTs to the Pi order server; the
+// kitchen sees it on /orders. No auth — anyone with the link can order.
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { getEntry } from 'astro:content';
+import { parseMenu, sectionItems } from '../lib/cafe-menu';
+
+// Base URL of the Pi order server (reached in prod via the Cloudflare Tunnel). Injected at build
+// time; falls back to the local uvicorn port so `astro dev` works out of the box.
+const ORDER_API = import.meta.env.PUBLIC_ORDER_API ?? 'http://localhost:8000';
+
+const page = await getEntry('pages', 'izzys-cafe');
+const sections = parseMenu(page?.body ?? '');
+const drinks = sectionItems(sections, 'Drinks');
+const milks = sectionItems(sections, 'Milks');
+const syrups = sectionItems(sections, 'Syrups');
+
+// Shared class strings, hoisted so a styling tweak happens in one place (mirrors upload.astro).
+const labelCls = 'block text-sm font-semibold text-neutral-800 dark:text-neutral-200';
+const optionalCls = 'font-normal text-neutral-400';
+const fieldInput =
+  'mt-1 w-full rounded-lg border border-neutral-300 bg-white px-3 py-2.5 text-neutral-900 placeholder:text-neutral-400 focus:border-accent-600 focus:outline-none focus:ring-2 focus:ring-accent-600/30 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100';
+// A selectable "chip" — the peer-checked variants light it up in accent pink when its input is picked.
+const chipCls =
+  'cursor-pointer select-none rounded-full border border-neutral-300 px-4 py-2 text-sm text-neutral-700 transition-colors peer-checked:border-accent-600 peer-checked:bg-accent-600 peer-checked:text-white peer-focus-visible:ring-2 peer-focus-visible:ring-accent-600/40 hover:border-accent-400 dark:border-neutral-700 dark:text-neutral-300 dark:peer-checked:text-white';
+---
+
+<BaseLayout title="Order" description="Place an order at Izzy's home cafe.">
+  <div class="max-w-xl">
+    <div id="closed-banner" class="mb-4 hidden rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm font-medium text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+      😴 The kitchen is closed — orders are paused right now.
+    </div>
+    <div class="flex items-baseline justify-between gap-3">
+      <h1 class="text-2xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">Order at Izzy's Cafe ☕</h1>
+      <a href="/orders/" class="shrink-0 text-sm text-accent-600 hover:underline dark:text-accent-100">See orders →</a>
+    </div>
+    <p class="mt-1 text-sm text-neutral-500 dark:text-neutral-500">Pick your drink, tweak it, and send it to the kitchen.</p>
+
+    <form id="order-form" data-order-api={ORDER_API} class="mt-6 space-y-7" novalidate>
+      <!-- Drink (required) -->
+      <fieldset>
+        <legend class={labelCls}>Drink <span class="text-accent-600">*</span></legend>
+        <div class="mt-2 flex flex-wrap gap-2">
+          {drinks.map((d, i) => (
+            <label>
+              <input type="radio" name="drink" value={d} required checked={i === 0} class="peer sr-only" />
+              <span class={chipCls}>{d}</span>
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      {milks.length > 0 && (
+        <fieldset>
+          <legend class={labelCls}>Milk <span class={optionalCls}>(optional)</span></legend>
+          <div class="mt-2 flex flex-wrap gap-2">
+            <label>
+              <input type="radio" name="milk" value="" checked class="peer sr-only" />
+              <span class={chipCls}>None</span>
+            </label>
+            {milks.map((m) => (
+              <label>
+                <input type="radio" name="milk" value={m} class="peer sr-only" />
+                <span class={chipCls}>{m}</span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+      )}
+
+      {syrups.length > 0 && (
+        <fieldset>
+          <legend class={labelCls}>Syrups <span class={optionalCls}>(pick any)</span></legend>
+          <div class="mt-2 flex flex-wrap gap-2">
+            {syrups.map((s) => (
+              <label>
+                <input type="checkbox" name="syrup" value={s} class="peer sr-only" />
+                <span class={chipCls}>{s}</span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+      )}
+
+      <div>
+        <label for="name" class={labelCls}>Name <span class="text-accent-600">*</span></label>
+        <input id="name" name="name" type="text" required autocomplete="name" maxlength="100" placeholder="Who's this for?" class={fieldInput} />
+      </div>
+
+      <div>
+        <label for="notes" class={labelCls}>Notes <span class={optionalCls}>(optional)</span></label>
+        <textarea id="notes" name="notes" rows="2" maxlength="500" placeholder="Extra hot, half sweet…" class={fieldInput}></textarea>
+      </div>
+
+      <div>
+        <button type="submit" id="submit-order"
+          class="w-full rounded-lg bg-accent-600 px-4 py-3 text-center font-semibold text-white transition-colors hover:bg-accent-700 disabled:opacity-60">
+          Send order 🚀
+        </button>
+        <p id="order-status" class="mt-2 text-sm" role="status" aria-live="polite"></p>
+      </div>
+    </form>
+  </div>
+
+  <script>
+    import { fetchKitchenOpen, pollWhileVisible } from '../scripts/order-status';
+
+    const form = document.getElementById('order-form');
+    const submitBtn = document.getElementById('submit-order');
+    const statusEl = document.getElementById('order-status');
+    const closedBanner = document.getElementById('closed-banner');
+    const STATUS_POLL_MS = 10000;
+    // Build-time config rides on the form's data attribute so this can be a module <script>.
+    const ORDER_API = form.dataset.orderApi;
+    let kitchenOpen = true;
+    // True while a submit is in flight, so a background status poll can't re-enable the button
+    // mid-request and let a double-click send a duplicate order.
+    let submitting = false;
+
+    // Show/hide the closed banner and lock the submit button to match the kitchen state.
+    function applyKitchen(open) {
+      kitchenOpen = open;
+      closedBanner.classList.toggle('hidden', open);
+      // Never re-enable while a submit is in flight; the submit's finally block owns that.
+      submitBtn.disabled = !open || submitting;
+      submitBtn.textContent = open ? 'Send order 🚀' : 'Kitchen closed 😴';
+    }
+
+    async function updateStatus() {
+      // Leave the form as-is if the Pi is unreachable (open === null); the POST is still guarded.
+      const open = await fetchKitchenOpen(ORDER_API);
+      if (open !== null) applyKitchen(open);
+    }
+
+    function setStatus(msg, kind = '') {
+      statusEl.textContent = msg;
+      statusEl.className =
+        'mt-2 text-sm ' +
+        (kind === 'ok' ? 'text-green-600 dark:text-green-500'
+          : kind === 'err' ? 'text-red-600 dark:text-red-400'
+          : 'text-neutral-500 dark:text-neutral-400');
+    }
+
+    const checkedValues = (name) =>
+      Array.from(form.querySelectorAll(`input[name="${name}"]:checked`)).map((el) => el.value).filter(Boolean);
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      if (!kitchenOpen) { setStatus('The kitchen is closed right now.', 'err'); return; }
+      const drink = form.querySelector('input[name="drink"]:checked')?.value;
+      if (!drink) { setStatus('Pick a drink first.', 'err'); return; }
+      const name = form.name.value.trim();
+      if (!name) { setStatus('Add your name first.', 'err'); return; }
+
+      const order = {
+        drink,
+        name,
+        milk: form.querySelector('input[name="milk"]:checked')?.value || undefined,
+        syrups: checkedValues('syrup'),
+        notes: form.notes.value.trim() || undefined,
+      };
+
+      submitting = true;
+      submitBtn.disabled = true;
+      setStatus('Sending…');
+      try {
+        const res = await fetch(`${ORDER_API}/orders`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(order),
+        });
+        // The kitchen closed since our last status poll — reflect that instead of a raw error.
+        if (res.status === 403) {
+          applyKitchen(false);
+          setStatus('The kitchen just closed — your order didn’t go through.', 'err');
+          return;
+        }
+        if (!res.ok) throw new Error(`Server error ${res.status}`);
+        setStatus('Order sent! The kitchen has it. ☕', 'ok');
+        // Reset the extras but keep the first drink selected, ready for the next order.
+        form.querySelectorAll('input[name="syrup"]').forEach((el) => (el.checked = false));
+        const noMilk = form.querySelector('input[name="milk"][value=""]');
+        if (noMilk) noMilk.checked = true;
+        form.name.value = '';
+        form.notes.value = '';
+      } catch (err) {
+        setStatus(err instanceof Error ? err.message : 'Could not send the order.', 'err');
+      } finally {
+        submitting = false;
+        // Respect a closed kitchen — applyKitchen(false) disables the button and we must not re-enable it.
+        submitBtn.disabled = !kitchenOpen;
+      }
+    });
+
+    // Reflect open/closed state on load, then keep polling (pausing when hidden, refetching on
+    // re-show) so the banner appears/clears on its own without a submit.
+    pollWhileVisible(updateStatus, STATUS_POLL_MS);
+  </script>
+</BaseLayout>

--- a/src/pages/orders.astro
+++ b/src/pages/orders.astro
@@ -1,0 +1,217 @@
+---
+// Kitchen display for the home cafe. Polls the Pi order server and shows a live New → Making → Done
+// board; tapping a card advances it. Meant to live on a screen in the kitchen. No auth — anyone with
+// the link can view/advance (by design). Orders are placed at /order.
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+const ORDER_API = import.meta.env.PUBLIC_ORDER_API ?? 'http://localhost:8000';
+// The OAuth Worker (same one /upload uses) — opening/closing the kitchen requires a GitHub sign-in,
+// verified server-side by the Pi against this Worker.
+const RECIPE_API = import.meta.env.PUBLIC_RECIPE_API ?? 'http://localhost:8787';
+
+const columns = [
+  { status: 'new', label: 'New', accent: 'border-accent-500' },
+  { status: 'making', label: 'Making', accent: 'border-amber-500' },
+  { status: 'done', label: 'Done', accent: 'border-green-500' },
+];
+const colHeadCls = 'text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400';
+---
+
+<BaseLayout title="Orders" description="Live kitchen queue for Izzy's home cafe.">
+  <div class="flex items-center justify-between gap-3">
+    <h1 class="text-2xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">Kitchen 🧑‍🍳</h1>
+    <div class="flex items-center gap-3">
+      <a href="/order/" class="shrink-0 text-sm text-accent-600 hover:underline dark:text-accent-100">← Order</a>
+      <span id="orders-meta" class="text-sm text-neutral-400"></span>
+      <button type="button" id="kitchen-toggle" data-order-api={ORDER_API} data-recipe-api={RECIPE_API}
+        class="rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-50">
+        …
+      </button>
+    </div>
+  </div>
+  <p class="mt-1 text-sm text-neutral-500 dark:text-neutral-500">Tap a card to move it along. Auto-refreshes.</p>
+
+  <div class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+    {columns.map((col) => (
+      <section class:list={['rounded-xl border-t-4 bg-neutral-50 p-3 dark:bg-neutral-900/40', col.accent]}>
+        <div class="flex items-center justify-between">
+          <h2 class={colHeadCls}>{col.label} <span data-count={col.status} class="ml-1 text-neutral-400">0</span></h2>
+          {col.status === 'done' && (
+            <button type="button" id="clear-done" class="text-xs font-medium text-neutral-500 hover:text-red-500">Clear</button>
+          )}
+        </div>
+        <div data-column={col.status} class="mt-3 space-y-2"></div>
+      </section>
+    ))}
+  </div>
+
+  <script>
+    import { currentSession, clearSession, ingestSessionFromHash } from '../scripts/recipe-session';
+    import { fetchKitchenOpen, pollWhileVisible } from '../scripts/order-status';
+
+    const NEXT = { new: 'making', making: 'done' };
+    const POLL_MS = 3500;
+    const meta = document.getElementById('orders-meta');
+    const toggle = document.getElementById('kitchen-toggle');
+    // Build-time config rides on the button's data attributes (see recipes/index.astro for the pattern),
+    // which lets this stay a module <script> that imports the shared session/status helpers.
+    const ORDER_API = toggle.dataset.orderApi;
+    const RECIPE_API = toggle.dataset.recipeApi;
+    let kitchenOpen = true;
+    // Disabled (showing "…") until the first status poll tells us the real open/closed state, so a
+    // click in that window can't toggle based on the stale default. renderKitchen() enables it.
+    toggle.disabled = true;
+
+    // Opening/closing the kitchen requires GitHub sign-in. The browser only holds the opaque session
+    // id; the Pi verifies it against the Worker. On return from OAuth the Worker redirects to
+    // /orders/#session=<id>, which ingestSessionFromHash() stashes and scrubs.
+    ingestSessionFromHash();
+    const signIn = () => { location.href = `${RECIPE_API}/login?return_to=/orders/`; };
+
+    // Reflect open/closed state onto the toggle button (red "Close" when open, green "Open" when closed).
+    function renderKitchen(open) {
+      kitchenOpen = open;
+      toggle.disabled = false; // real state is known now — clickable
+      toggle.textContent = open ? 'Close kitchen' : 'Open kitchen';
+      toggle.className =
+        'rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-50 ' +
+        (open
+          ? 'border-red-300 text-red-600 hover:bg-red-50 dark:border-red-900 dark:text-red-400 dark:hover:bg-red-950/40'
+          : 'border-green-400 text-green-700 hover:bg-green-50 dark:border-green-800 dark:text-green-400 dark:hover:bg-green-950/40');
+    }
+
+    toggle.addEventListener('click', async () => {
+      // Gate on GitHub sign-in — no session means kick off OAuth (we come back to /orders/ signed in).
+      if (!currentSession()) { signIn(); return; }
+      toggle.disabled = true;
+      try {
+        const res = await fetch(`${ORDER_API}/status`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${currentSession()}` },
+          body: JSON.stringify({ open: !kitchenOpen }),
+        });
+        if (res.status === 401) {
+          // Session missing/expired on the server — drop it and restart sign-in.
+          clearSession();
+          signIn();
+          return;
+        }
+        if (res.ok) renderKitchen((await res.json()).open);
+      } catch { /* leave the button as-is; next poll re-syncs */ }
+      finally { toggle.disabled = false; }
+    });
+
+    async function patchStatus(id, status) {
+      const res = await fetch(`${ORDER_API}/orders/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status }),
+      });
+      if (!res.ok) throw new Error(`Server error ${res.status}`);
+    }
+
+    // Build one order card. Uses textContent throughout — name/notes are user input and must never
+    // be parsed as markup.
+    function card(order) {
+      const el = document.createElement('article');
+      el.className =
+        'rounded-lg border border-neutral-200 bg-white p-3 shadow-sm dark:border-neutral-800 dark:bg-neutral-900';
+
+      const drink = document.createElement('div');
+      drink.className = 'font-semibold text-neutral-900 dark:text-neutral-100';
+      drink.textContent = order.drink;
+      el.appendChild(drink);
+
+      const bits = [];
+      if (order.milk) bits.push(order.milk);
+      if (order.syrups && order.syrups.length) bits.push(order.syrups.join(', '));
+      if (bits.length) {
+        const sub = document.createElement('div');
+        sub.className = 'mt-0.5 text-sm text-neutral-600 dark:text-neutral-400';
+        sub.textContent = bits.join(' · ');
+        el.appendChild(sub);
+      }
+
+      if (order.name) {
+        const who = document.createElement('div');
+        who.className = 'mt-1 text-sm font-medium text-accent-600 dark:text-accent-100';
+        who.textContent = order.name;
+        el.appendChild(who);
+      }
+
+      if (order.notes) {
+        const notes = document.createElement('div');
+        notes.className = 'mt-1 text-sm italic text-neutral-500 dark:text-neutral-400';
+        notes.textContent = order.notes;
+        el.appendChild(notes);
+      }
+
+      const next = NEXT[order.status];
+      if (next) {
+        el.classList.add('cursor-pointer', 'transition-colors', 'hover:border-accent-400');
+        el.title = `Move to ${next}`;
+        el.addEventListener('click', async () => {
+          el.style.opacity = '0.5';
+          try { await patchStatus(order.id, next); await refresh(); }
+          catch { el.style.opacity = '1'; }
+        });
+      } else {
+        // Done cards can be archived individually.
+        const archive = document.createElement('button');
+        archive.type = 'button';
+        archive.className = 'mt-2 text-xs text-neutral-400 hover:text-red-500';
+        archive.textContent = 'Archive';
+        archive.addEventListener('click', async () => {
+          try { await patchStatus(order.id, 'archived'); await refresh(); } catch { /* keep it visible */ }
+        });
+        el.appendChild(archive);
+      }
+      return el;
+    }
+
+    // Last-rendered orders, so "Clear done" can archive from known state without re-fetching.
+    let lastOrders = [];
+
+    function render(orders) {
+      lastOrders = orders;
+      const byStatus = { new: [], making: [], done: [] };
+      for (const o of orders) if (byStatus[o.status]) byStatus[o.status].push(o);
+      for (const status of Object.keys(byStatus)) {
+        const col = document.querySelector(`[data-column="${status}"]`);
+        const count = document.querySelector(`[data-count="${status}"]`);
+        col.replaceChildren(...byStatus[status].map(card));
+        if (count) count.textContent = String(byStatus[status].length);
+      }
+    }
+
+    async function refresh() {
+      // The status and orders GETs are independent — fetch them together, not one after the other.
+      // (Status also keeps the toggle in sync, so a second kitchen screen reflects a change.)
+      const [open, ordersRes] = await Promise.all([
+        fetchKitchenOpen(ORDER_API),
+        fetch(`${ORDER_API}/orders`, { headers: { Accept: 'application/json' } }).catch(() => null),
+      ]);
+      if (open !== null) renderKitchen(open);
+      if (ordersRes && ordersRes.ok) {
+        render(await ordersRes.json());
+        meta.textContent = 'live';
+        meta.className = 'text-sm text-green-600 dark:text-green-500';
+      } else {
+        meta.textContent = 'offline — retrying';
+        meta.className = 'text-sm text-red-500';
+      }
+    }
+
+    document.getElementById('clear-done').addEventListener('click', async () => {
+      // Archive from the board's known state (no extra fetch), then refresh once.
+      const done = lastOrders.filter((o) => o.status === 'done');
+      if (!done.length) return;
+      await Promise.allSettled(done.map((o) => patchStatus(o.id, 'archived')));
+      await refresh();
+    });
+
+    // Poll only while the tab is visible — a kitchen screen left open shouldn't hammer the Pi
+    // when it's in the background.
+    pollWhileVisible(refresh, POLL_MS);
+  </script>
+</BaseLayout>

--- a/src/scripts/order-status.ts
+++ b/src/scripts/order-status.ts
@@ -1,0 +1,41 @@
+// Shared client helpers for the cafe order pages (/order and /orders). Kitchen open/closed status is
+// public (no auth), so both pages fetch it the same way and both poll on the same visibility-aware
+// cadence — factored here so the endpoint and the poll lifecycle live in one place.
+
+// Fetch whether the kitchen is open. Returns null if unreachable, so callers can leave the UI as-is
+// for that tick rather than flipping state on a transient network blip.
+export async function fetchKitchenOpen(apiBase: string): Promise<boolean | null> {
+  try {
+    const res = await fetch(`${apiBase}/status`, { headers: { Accept: 'application/json' } });
+    if (res.ok) return (await res.json()).open;
+  } catch {
+    /* unreachable — caller decides how to degrade */
+  }
+  return null;
+}
+
+// Run `fn` now and every `ms`, but only while the tab is visible: pause on hide, and refetch + resume
+// on re-show so switching back to the page updates it immediately without hammering the Pi in the
+// background.
+export function pollWhileVisible(fn: () => void, ms: number): void {
+  let timer: ReturnType<typeof setInterval> | null = null;
+  const start = () => {
+    stop();
+    timer = setInterval(fn, ms);
+  };
+  const stop = () => {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) stop();
+    else {
+      fn();
+      start();
+    }
+  });
+  fn();
+  start();
+}

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -42,7 +42,7 @@ const SLUG_RE = /^[a-z0-9-]+$/;
 
 // Pages sign-in may return to. An allowlist (not raw reflection of `return_to`) keeps the
 // post-OAuth redirect from becoming an open redirect. First entry is the default fallback.
-const RETURN_PATHS = ['/upload', '/recipes/'];
+const RETURN_PATHS = ['/upload', '/recipes/', '/orders/'];
 const DEFAULT_RETURN = RETURN_PATHS[0];
 const safeReturn = (path: string | null): string =>
   path && RETURN_PATHS.includes(path) ? path : DEFAULT_RETURN;
@@ -88,6 +88,11 @@ export default {
           return await withSession(request, env, (_id, s) => deleteRecipe(request, env, s));
         case 'POST /logout':
           return await withSession(request, env, (id) => logout(env, id));
+        case 'GET /api/me':
+          // Lightweight session check for other first-party backends (e.g. the Pi order server,
+          // which gates the kitchen open/close toggle on it). A valid session can only belong to
+          // ALLOWED_LOGIN — it's minted nowhere else — so "session valid" == "the allowed user".
+          return await withSession(request, env, async () => json(env, 200, { ok: true }));
         case 'GET /':
           return json(env, 200, { ok: true, service: 'izzy-recipe-api' });
         default:


### PR DESCRIPTION
Adds a home-cafe ordering flow: place orders at **/order**, watch them on a live kitchen board at **/orders**. Backed by a Raspberry Pi (FastAPI + SQLite) reached from the HTTPS site via a Cloudflare Tunnel.

## What's in it
- **`/order`** — customer form built at build time from the existing `izzys-cafe` menu markdown via a shared parser (`src/lib/cafe-menu.ts`), so options never drift from the menu or the `/izzys-cafe.json` dizzyos feed. Drink + name required; milk / syrups / notes optional.
- **`/orders`** — live **New → Making → Done** kitchen board: tap a card to advance, auto-refreshing poll (pauses when the tab's hidden). Unlisted in nav (reached via cross-links between the two pages), same treatment as `/upload`.
- **Close Kitchen** — a GitHub-gated open/close toggle on `/orders`. Kitchen state lives on the Pi: `GET /status` is public (drives the "kitchen is closed" banner + disabled submit on `/order`), but `POST /status` requires a valid recipe session, which the Pi verifies against the OAuth Worker's new `GET /api/me`. A closed kitchen also rejects `POST /orders` with 403 server-side.
- **`order-server/`** — the FastAPI app + README (venv, systemd, and `cloudflared` tunnel setup). CORS locked to the site origin (any localhost port allowed in dev).
- **Build wiring** — `PUBLIC_ORDER_API` injected in `deploy.yml`, mirroring the existing `PUBLIC_RECIPE_API` pattern.

## Deploy steps (not automated — see `order-server/README.md`)
- Move izzybennett.com DNS to Cloudflare; run the FastAPI server + `cloudflared` on the Pi (systemd).
- Set repo Actions variable `PUBLIC_ORDER_API=https://orders.izzybennett.com`.
- **Redeploy the Worker** (adds `GET /api/me` + `/orders/` OAuth return path).
- Set `RECIPE_API` env on the Pi to the Worker URL so the kitchen toggle can verify sign-ins.

## Testing
Verified end-to-end locally (FastAPI + `astro dev`): create/list/advance/archive, name-required (422) + closed-kitchen (403) guards, GitHub-gated toggle (success + fail-closed), and CORS preflight incl. `Authorization`. Ran `/simplify` and `/code-review` over the diff; applied the cleanups + the top correctness fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)