### PR TITLE
fix: kitchen toggle shows "Kitchen offline" instead of a stuck "…", offlinemaxxing

### DIFF
--- a/src/pages/order.astro
+++ b/src/pages/order.astro
@@ -8,8 +8,11 @@ import { getEntry } from 'astro:content';
 import { parseMenu, sectionItems } from '../lib/cafe-menu';
 
 // Base URL of the Pi order server (reached in prod via the Cloudflare Tunnel). Injected at build
-// time; falls back to the local uvicorn port so `astro dev` works out of the box.
-const ORDER_API = import.meta.env.PUBLIC_ORDER_API ?? 'http://localhost:8000';
+// time. `||` (not `??`) so an unset GitHub Actions var — which arrives as an empty string — falls
+// back too; the local uvicorn port is used only in dev so `astro dev` works out of the box, while a
+// misconfigured prod build yields an empty base (fetchKitchenOpen short-circuits) rather than
+// polling same-origin /status.
+const ORDER_API = import.meta.env.PUBLIC_ORDER_API || (import.meta.env.DEV ? 'http://localhost:8000' : '');
 
 const page = await getEntry('pages', 'izzys-cafe');
 const sections = parseMenu(page?.body ?? '');

--- a/src/pages/orders.astro
+++ b/src/pages/orders.astro
@@ -4,10 +4,13 @@
 // the link can view/advance (by design). Orders are placed at /order.
 import BaseLayout from '../layouts/BaseLayout.astro';
 
-const ORDER_API = import.meta.env.PUBLIC_ORDER_API ?? 'http://localhost:8000';
+// `||` (not `??`) so an unset GitHub Actions var — which arrives as an empty string, not undefined —
+// falls back too; and the localhost default only applies in dev, so a misconfigured prod build yields
+// an empty base the client can treat explicitly as "offline" rather than polling same-origin /status.
+const ORDER_API = import.meta.env.PUBLIC_ORDER_API || (import.meta.env.DEV ? 'http://localhost:8000' : '');
 // The OAuth Worker (same one /upload uses) — opening/closing the kitchen requires a GitHub sign-in,
 // verified server-side by the Pi against this Worker.
-const RECIPE_API = import.meta.env.PUBLIC_RECIPE_API ?? 'http://localhost:8787';
+const RECIPE_API = import.meta.env.PUBLIC_RECIPE_API || (import.meta.env.DEV ? 'http://localhost:8787' : '');
 
 const columns = [
   { status: 'new', label: 'New', accent: 'border-accent-500' },
@@ -58,6 +61,10 @@ const colHeadCls = 'text-xs font-semibold uppercase tracking-wide text-neutral-5
     const ORDER_API = toggle.dataset.orderApi;
     const RECIPE_API = toggle.dataset.recipeApi;
     let kitchenOpen = true;
+    // Flips true the first time we learn the real open/closed state from the server. Until then a
+    // failed poll means "never reached the server" (show offline); after it, a transient failure is
+    // just a blip and we keep the last-known label.
+    let hasResolved = false;
     // Disabled (showing "…") until the first status poll tells us the real open/closed state, so a
     // click in that window can't toggle based on the stale default. renderKitchen() enables it.
     toggle.disabled = true;
@@ -78,6 +85,16 @@ const colHeadCls = 'text-xs font-semibold uppercase tracking-wide text-neutral-5
         (open
           ? 'border-red-300 text-red-600 hover:bg-red-50 dark:border-red-900 dark:text-red-400 dark:hover:bg-red-950/40'
           : 'border-green-400 text-green-700 hover:bg-green-50 dark:border-green-800 dark:text-green-400 dark:hover:bg-green-950/40');
+    }
+
+    // Order server unreachable or unconfigured: show a clearly-disabled "offline" control instead of
+    // the mysterious "…" placeholder, so the button never looks like it's simply missing.
+    function renderKitchenUnavailable() {
+      toggle.disabled = true;
+      toggle.textContent = 'Kitchen offline';
+      toggle.className =
+        'rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-50 ' +
+        'border-neutral-300 text-neutral-400 dark:border-neutral-700 dark:text-neutral-500';
     }
 
     toggle.addEventListener('click', async () => {
@@ -191,7 +208,8 @@ const colHeadCls = 'text-xs font-semibold uppercase tracking-wide text-neutral-5
         fetchKitchenOpen(ORDER_API),
         fetch(`${ORDER_API}/orders`, { headers: { Accept: 'application/json' } }).catch(() => null),
       ]);
-      if (open !== null) renderKitchen(open);
+      if (open !== null) { renderKitchen(open); hasResolved = true; }
+      else if (!hasResolved) renderKitchenUnavailable(); // never reached the server — show offline, not "…"
       if (ordersRes && ordersRes.ok) {
         render(await ordersRes.json());
         meta.textContent = 'live';
@@ -210,8 +228,16 @@ const colHeadCls = 'text-xs font-semibold uppercase tracking-wide text-neutral-5
       await refresh();
     });
 
-    // Poll only while the tab is visible — a kitchen screen left open shouldn't hammer the Pi
-    // when it's in the background.
-    pollWhileVisible(refresh, POLL_MS);
+    if (!ORDER_API) {
+      // No order server configured for this build (PUBLIC_ORDER_API unset) — there's nothing to poll.
+      // Show the offline toggle and a clear board note instead of hammering same-origin 404s.
+      renderKitchenUnavailable();
+      meta.textContent = 'not configured';
+      meta.className = 'text-sm text-neutral-400';
+    } else {
+      // Poll only while the tab is visible — a kitchen screen left open shouldn't hammer the Pi
+      // when it's in the background.
+      pollWhileVisible(refresh, POLL_MS);
+    }
   </script>
 </BaseLayout>

--- a/src/scripts/order-status.ts
+++ b/src/scripts/order-status.ts
@@ -5,6 +5,9 @@
 // Fetch whether the kitchen is open. Returns null if unreachable, so callers can leave the UI as-is
 // for that tick rather than flipping state on a transient network blip.
 export async function fetchKitchenOpen(apiBase: string): Promise<boolean | null> {
+  // No base URL configured (e.g. PUBLIC_ORDER_API unset in prod) — don't fire a bogus same-origin
+  // GET /status; just report "unknown" so callers show an offline state instead of 404-spamming.
+  if (!apiBase) return null;
   try {
     const res = await fetch(`${apiBase}/status`, { headers: { Accept: 'application/json' } });
     if (res.ok) return (await res.json()).open;


### PR DESCRIPTION
## What & why

The **Close/Open kitchen** toggle on `/orders` never showed up on the live site — it stayed stuck as its faded, disabled `…` placeholder. Root cause: the button only becomes real after a successful poll of `GET {ORDER_API}/status`, and in prod that poll can't succeed.

- GitHub Actions passes `PUBLIC_ORDER_API: ${{ vars.PUBLIC_ORDER_API }}`; when the var is **unset** it arrives as an **empty string**, not undefined.
- `import.meta.env.PUBLIC_ORDER_API ?? 'http://localhost:8000'` — `??` only falls back on null/undefined, so `ORDER_API = ''`.
- The browser then polls same-origin `/status` (404) → `fetchKitchenOpen` returns `null` → `renderKitchen()` never runs → button stuck at `…` forever, with zero indication. (Live HTML confirmed: `<button id="kitchen-toggle" data-order-api ...>` — a bare, valueless attribute.)

## Changes

- **`order-status.ts`** — `fetchKitchenOpen` short-circuits to `null` on an empty base URL, so an unconfigured build never fires a bogus same-origin request.
- **`orders.astro`** — `||` (+ dev-only localhost) fallback so an empty var no longer slips through; new visible, disabled **"Kitchen offline"** state (`renderKitchenUnavailable`) shown on the first failed poll or when no order API is configured, instead of the mysterious `…`. Polling is skipped entirely when unconfigured.
- **`order.astro`** — same `||`/dev fallback for consistency (it had the identical footgun; on prod it left the order form optimistically "open" and submitting into the void).

## Verification

- `astro build` with no `PUBLIC_ORDER_API` succeeds; built `/orders` bakes an empty (not localhost) base, proving the `import.meta.env.DEV` gate.
- Faithful harness (real compiled sources): `fetchKitchenOpen("")` / `fetchKitchenOpen(undefined)` return `null` with **no** network call; the real built button's `dataset.orderApi` is `""` (falsy) → startup takes the offline branch. Compiled bundle confirms `ORDER_API ? poll : (renderKitchenUnavailable(), "not configured")` and the `Kitchen offline` label.

## ⚠️ Out of scope — ops prerequisite

This makes the button *look* correct when offline; it can only *work* once the order server is reachable. Still needed: set the Actions repo var `PUBLIC_ORDER_API=https://orders.izzybennett.com`, bring up the Pi FastAPI server + `cloudflared` tunnel, and redeploy the Worker.

_Supersedes #25 (which was mistakenly based on the already-squash-merged `feat/home-cafe-ordering`)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)