### PR TITLE
feat: /update-menu — edit the cafe menu from your phone, menumaxxing

### DIFF
--- a/src/lib/cafe-menu.ts
+++ b/src/lib/cafe-menu.ts
@@ -10,6 +10,11 @@ export interface MenuSection {
   items: string[];
 }
 
+// The canonical menu sections, in order. The order form assigns per-section meaning by these exact
+// names (Drinks → drink, Milks → milk, Syrups → syrups, Food is menu-only), so the menu editor
+// (`/update-menu`) locks the list here rather than letting section names be edited freely.
+export const MENU_SECTIONS = ['Drinks', 'Milks', 'Syrups', 'Food'] as const;
+
 export function parseMenu(body: string): MenuSection[] {
   const sections: MenuSection[] = [];
   let current: MenuSection | null = null;

--- a/src/pages/update-menu.astro
+++ b/src/pages/update-menu.astro
@@ -1,0 +1,335 @@
+---
+// Standalone, unlisted cafe-menu editor. Like /upload it deliberately does NOT use BaseLayout,
+// so it stays out of the site chrome. It edits the single source-of-truth menu file
+// (src/content/pages/izzys-cafe.md) by building the markdown client-side and handing it to the
+// recipe API Worker, which — after a GitHub OAuth sign-in — commits it to the repo. The GitHub
+// token never reaches the browser; this page only ever holds an opaque session id. The commit
+// triggers the normal GitHub Pages deploy, so the order form, /izzys-cafe.json feed, and the
+// dizzyos LED sign all pick up the change. See /worker for the backend.
+import '../styles/global.css';
+import { getEntry } from 'astro:content';
+import { parseMenu, sectionItems, MENU_SECTIONS } from '../lib/cafe-menu';
+
+// Base URL of the recipe API Worker (the OAuth backend + write proxy). Injected at build time;
+// falls back to the local `wrangler dev` port so `astro dev` works out of the box. Shared with
+// /upload — one GitHub sign-in covers both.
+const RECIPE_API = import.meta.env.PUBLIC_RECIPE_API ?? 'http://localhost:8787';
+
+// The fixed sections the editor manages, in order — the canonical list from the menu lib. Names
+// are not editable: the order form looks sections up by these exact headings (see order.astro).
+const SECTIONS = MENU_SECTIONS;
+
+// Build-time snapshot of the current menu, keyed by heading. Used only as a fallback: if the
+// runtime /izzys-cafe.json fetch in loadLatest() fails, the editor still shows the baked-in menu.
+const page = await getEntry('pages', 'izzys-cafe');
+const parsed = parseMenu(page?.body ?? '');
+const menuTitle = page?.data.title ?? "Izzy's Cafe";
+const initialItems = Object.fromEntries(SECTIONS.map((h) => [h, sectionItems(parsed, h)]));
+
+// Shared class strings, mirrored from /upload so the two editors look like one system.
+const rowInput =
+  'min-w-0 flex-1 rounded-lg border border-neutral-300 bg-white px-3 py-2 text-neutral-900 placeholder:text-neutral-400 focus:border-accent-600 focus:outline-none focus:ring-2 focus:ring-accent-600/30 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100';
+const sectionHeading = 'text-sm font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-500';
+const addBtn =
+  'rounded-md px-2 py-1 text-sm font-medium text-accent-600 hover:bg-accent-50 dark:text-accent-100 dark:hover:bg-neutral-900';
+const removeBtn =
+  'shrink-0 rounded-lg border border-neutral-300 px-3 text-neutral-400 hover:border-red-400 hover:text-red-500 dark:border-neutral-700';
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow" />
+    <meta name="theme-color" content="#db2777" />
+    <link rel="icon" href="/favicon.ico" />
+    <title>Update the menu · Izzy's Cafe</title>
+  </head>
+  <body class="min-h-screen bg-white text-neutral-800 dark:bg-neutral-950 dark:text-neutral-200">
+    <main class="mx-auto w-full max-w-2xl px-4 py-8 sm:px-6">
+      <header class="flex items-baseline justify-between gap-3">
+        <h1 class="text-2xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">Update the menu</h1>
+        <a href="/order/" class="text-sm text-accent-600 hover:underline dark:text-accent-100">← Order</a>
+      </header>
+      <p class="mt-1 text-sm text-neutral-500 dark:text-neutral-500">Tweak the items, hit save, and it goes live in a minute or two — on the order form, the JSON feed, and the sign.</p>
+
+      <!-- Auth bar. Sign-in kicks off GitHub OAuth on the Worker; on return the page holds
+           only an opaque session id (never a GitHub token). -->
+      <div class="mt-4 flex items-center gap-3 rounded-lg border border-neutral-200 bg-neutral-50 p-3 dark:border-neutral-800 dark:bg-neutral-900">
+        <span id="auth-state" class="text-sm text-neutral-500 dark:text-neutral-400">Checking sign-in…</span>
+        <a id="signin-btn" href={`${RECIPE_API}/login?return_to=/update-menu`}
+          class="ml-auto hidden rounded-lg bg-neutral-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-neutral-700 dark:bg-white dark:text-neutral-900 dark:hover:bg-neutral-200">
+          Sign in with GitHub
+        </a>
+        <button type="button" id="signout-btn"
+          class="ml-auto hidden rounded-lg border border-neutral-300 px-3 py-1.5 text-sm font-medium text-neutral-700 hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800">
+          Sign out
+        </button>
+      </div>
+
+      <form id="menu-form" class="mt-6 space-y-8" novalidate>
+        {SECTIONS.map((heading) => (
+          <section data-section={heading}>
+            <div class="flex items-center justify-between">
+              <h2 class={sectionHeading}>{heading}</h2>
+              <button type="button" data-action="add" class={addBtn}>+ Add</button>
+            </div>
+            <div class="items-list mt-2 space-y-2"></div>
+          </section>
+        ))}
+
+        <!-- Preview -->
+        <details id="preview-details" class="rounded-lg border border-neutral-200 dark:border-neutral-800">
+          <summary class="cursor-pointer px-3 py-2 text-sm font-medium text-neutral-700 dark:text-neutral-300">Preview markdown</summary>
+          <div class="border-t border-neutral-200 p-3 dark:border-neutral-800">
+            <pre id="preview" class="max-h-80 overflow-auto whitespace-pre-wrap rounded bg-neutral-50 p-3 text-xs text-neutral-700 dark:bg-neutral-900 dark:text-neutral-300"></pre>
+          </div>
+        </details>
+
+        <!-- Actions -->
+        <div class="sticky bottom-0 -mx-4 border-t border-neutral-200 bg-white/90 px-4 py-3 backdrop-blur sm:-mx-6 sm:px-6 dark:border-neutral-800 dark:bg-neutral-950/90">
+          <button type="submit" id="save"
+            class="w-full rounded-lg bg-accent-600 px-4 py-3 text-center font-semibold text-white transition-colors hover:bg-accent-700 disabled:opacity-60">
+            Save menu 🚀
+          </button>
+          <p id="status" class="mt-2 text-sm" role="status" aria-live="polite"></p>
+        </div>
+      </form>
+    </main>
+
+    <!-- Single-line item row. -->
+    <template id="tpl-row">
+      <div data-unit="row" class="flex gap-2">
+        <input type="text" autocomplete="off" enterkeyhint="done" placeholder="Item name…" class={rowInput} />
+        <button type="button" data-action="remove" aria-label="Remove" class={removeBtn}>✕</button>
+      </div>
+    </template>
+
+    <script define:vars={{ RECIPE_API, SECTIONS, menuTitle, initialItems }}>
+      // ---- Config ---------------------------------------------------------
+      // RECIPE_API is injected from the frontmatter above. The browser only ever holds the
+      // opaque session id under SESSION_KEY (shared with /upload) — never a GitHub token.
+      const API = RECIPE_API;
+      const SESSION_KEY = 'izzy-recipe-session';
+
+      const $ = (sel) => document.querySelector(sel);
+      const form = $('#menu-form');
+      const statusEl = $('#status');
+      const previewEl = $('#preview');
+      const previewDetails = $('#preview-details');
+      const saveBtn = $('#save');
+      const authState = $('#auth-state');
+      const signinBtn = $('#signin-btn');
+      const signoutBtn = $('#signout-btn');
+
+      // The title currently in the menu file; carried through on save so we never drop it. Seeded
+      // from the build-time value, refreshed from /izzys-cafe.json on load.
+      let currentTitle = menuTitle;
+
+      // ---- Rows -----------------------------------------------------------
+      // The four section item-lists are rendered once at build time and never move, so cache them
+      // by heading — the hot paths (populate / readSections / toMarkdown) then skip re-scanning the
+      // form on every call.
+      const rowTpl = $('#tpl-row');
+      const listByHeading = new Map(
+        SECTIONS.map((heading) => [heading, form.querySelector(`section[data-section="${heading}"] .items-list`)])
+      );
+
+      function addRow(heading, value = '') {
+        const row = rowTpl.content.firstElementChild.cloneNode(true);
+        row.querySelector('input').value = value;
+        listByHeading.get(heading).appendChild(row);
+        return row;
+      }
+
+      // Replace every section's rows from a { heading: [items] } map (missing → empty section).
+      function populate(itemsByHeading) {
+        for (const heading of SECTIONS) {
+          listByHeading.get(heading).innerHTML = '';
+          for (const item of itemsByHeading[heading] ?? []) addRow(heading, item);
+        }
+        refreshPreview();
+      }
+
+      // ---- Add / remove / edit (event delegation) -------------------------
+      // Tracks whether the user has touched the form since load, so the async loadLatest() refresh
+      // below never clobbers in-progress edits.
+      let formDirty = false;
+      const markDirty = () => { formDirty = true; };
+
+      form.addEventListener('click', (e) => {
+        const btn = e.target.closest('button[data-action]');
+        if (!btn) return;
+        if (btn.dataset.action === 'add') {
+          markDirty();
+          addRow(btn.closest('section[data-section]').dataset.section).querySelector('input').focus();
+        } else if (btn.dataset.action === 'remove') {
+          markDirty();
+          btn.closest('[data-unit]')?.remove();
+          refreshPreview();
+        }
+      });
+
+      form.addEventListener('input', () => { markDirty(); refreshPreview(); });
+
+      // Enter inside an item field would implicitly submit the form — an immediate menu commit.
+      // Intercept it: add another item row in that section instead (natural for list entry) and
+      // leave saving to the explicit button, so a stray keypress can't publish a half-edited menu.
+      form.addEventListener('keydown', (e) => {
+        if (e.key !== 'Enter') return;
+        const input = e.target.closest('input[type="text"]');
+        if (!input) return;
+        e.preventDefault();
+        markDirty();
+        const section = input.closest('section[data-section]');
+        if (section) addRow(section.dataset.section).querySelector('input').focus();
+      });
+
+      // ---- Read form → markdown -------------------------------------------
+      function readSections() {
+        return SECTIONS.map((heading) => ({
+          heading,
+          items: Array.from(listByHeading.get(heading).querySelectorAll('input'))
+            .map((el) => el.value.trim())
+            .filter(Boolean),
+        }));
+      }
+
+      // Double-quoted YAML scalar for the title (only frontmatter key the menu file has).
+      const q = (s) =>
+        '"' +
+        s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t') +
+        '"';
+
+      function toMarkdown() {
+        const L = ['---', `title: ${q(currentTitle)}`, '---', '', '## Menu', ''];
+        for (const { heading, items } of readSections()) {
+          L.push(`#### ${heading}`);
+          for (const item of items) L.push(`- ${item}`);
+          L.push('');
+        }
+        return L.join('\n');
+      }
+
+      function refreshPreview() {
+        if (!previewDetails.open) return;
+        previewEl.textContent = toMarkdown();
+      }
+      previewDetails.addEventListener('toggle', refreshPreview);
+
+      // ---- Session / auth (inline; a define:vars script can't import a module) --------------
+      const currentSession = () => localStorage.getItem(SESSION_KEY);
+      const clearSession = () => localStorage.removeItem(SESSION_KEY);
+
+      // On return from OAuth the Worker redirects to /update-menu#session=<id>. Pull it out of the
+      // fragment (fragments never hit a server or log), stash it, then scrub the URL.
+      function ingestSessionFromHash() {
+        const prefix = '#session=';
+        if (location.hash.startsWith(prefix)) {
+          const id = location.hash.slice(prefix.length);
+          if (id) localStorage.setItem(SESSION_KEY, id);
+          history.replaceState(null, '', location.pathname + location.search);
+        }
+      }
+
+      function renderAuthState() {
+        const signed = !!currentSession();
+        authState.textContent = signed ? '✓ Signed in with GitHub' : 'Not signed in';
+        authState.className =
+          'text-sm ' + (signed ? 'text-green-600 dark:text-green-500' : 'text-neutral-500 dark:text-neutral-400');
+        signinBtn.classList.toggle('hidden', signed);
+        signoutBtn.classList.toggle('hidden', !signed);
+      }
+
+      signoutBtn.addEventListener('click', async () => {
+        const session = currentSession();
+        if (session) {
+          try {
+            await fetch(`${API}/logout`, { method: 'POST', headers: { Authorization: `Bearer ${session}` } });
+          } catch { /* offline is fine — we still drop the local id */ }
+        }
+        clearSession();
+        renderAuthState();
+        setStatus('Signed out.', 'ok');
+      });
+
+      // ---- Status ---------------------------------------------------------
+      // textContent (not innerHTML) — messages can include server-returned error text.
+      function setStatus(msg, kind = '') {
+        statusEl.textContent = msg;
+        statusEl.className =
+          'mt-2 text-sm ' +
+          (kind === 'ok' ? 'text-green-600 dark:text-green-500'
+            : kind === 'err' ? 'text-red-600 dark:text-red-400'
+            : 'text-neutral-500 dark:text-neutral-400');
+      }
+
+      // ---- API (via the Worker) -------------------------------------------
+      function apiFetch(path, options = {}) {
+        const session = currentSession();
+        return fetch(`${API}${path}`, {
+          ...options,
+          headers: { Authorization: `Bearer ${session}`, 'Content-Type': 'application/json', ...(options.headers || {}) },
+        });
+      }
+
+      async function apiError(res) {
+        let msg = '';
+        try { msg = (await res.json()).error ?? ''; } catch { /* noop */ }
+        if (res.status === 401) {
+          clearSession();
+          renderAuthState();
+          return msg || 'Session expired — sign in again.';
+        }
+        return msg || `Server error ${res.status}.`;
+      }
+
+      // ---- Submit ---------------------------------------------------------
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        if (!currentSession()) {
+          setStatus('Sign in with GitHub first (top of the page).', 'err');
+          return;
+        }
+        saveBtn.disabled = true;
+        try {
+          setStatus('Saving…', 'info');
+          const res = await apiFetch('/api/menu', {
+            method: 'POST',
+            body: JSON.stringify({ markdown: toMarkdown(), message: 'Update cafe menu' }),
+          });
+          if (!res.ok) throw new Error(await apiError(res));
+          setStatus("Saved! 🎉 It'll be live in a minute or two.", 'ok');
+        } catch (err) {
+          setStatus(err instanceof Error ? err.message : 'Something went wrong.', 'err');
+        } finally {
+          saveBtn.disabled = false;
+        }
+      });
+
+      // ---- Init -----------------------------------------------------------
+      // Prefill from the build-time snapshot, then refresh from the live feed so the editor is
+      // current even if this page was built a while ago. A failed fetch just keeps the snapshot.
+      async function loadLatest() {
+        try {
+          const res = await fetch('/izzys-cafe.json', { headers: { Accept: 'application/json' } });
+          if (!res.ok) return;
+          const data = await res.json();
+          if (formDirty) return; // user started editing while the fetch was in flight — don't clobber it
+          if (typeof data.title === 'string' && data.title) currentTitle = data.title;
+          const byHeading = {};
+          for (const s of data.sections ?? []) byHeading[s.heading] = s.items;
+          populate(byHeading);
+        } catch {
+          /* keep the baked-in snapshot */
+        }
+      }
+
+      ingestSessionFromHash();
+      renderAuthState();
+      populate(initialItems);
+      loadLatest();
+    </script>
+  </body>
+</html>

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -9,11 +9,13 @@
  *                        then 302 back to the site with the session id in the URL fragment.
  *   POST   /api/recipe → create/update a recipe file (auth: `Authorization: Bearer <session>`)
  *   DELETE /api/recipe → delete a recipe file
+ *   POST   /api/menu   → overwrite the cafe menu file (auth: `Authorization: Bearer <session>`)
  *   POST   /logout     → destroy the session
  *
  * The browser only ever holds the opaque session id. The GitHub token lives in KV and is
  * injected server-side here, and every proxied call is hard-restricted to RECIPE_DIR/<slug>.md
- * on OWNER/REPO@BRANCH — so a leaked session can only ever touch recipe files.
+ * or the single fixed MENU_PATH on OWNER/REPO@BRANCH — so a leaked session can only ever touch
+ * those files.
  */
 
 export interface Env {
@@ -41,9 +43,14 @@ const GH_OAUTH = 'https://github.com/login/oauth';
 const UA = 'izzy-recipe-worker';
 const SLUG_RE = /^[a-z0-9-]+$/;
 
+// The one fixed file the /api/menu route may write — the cafe menu, single source of truth for
+// the order form, the /izzys-cafe.json feed, and the dizzyos LED sign. Hard-coded (not derived
+// from client input) so a menu save can never reach any other path.
+const MENU_PATH = 'src/content/pages/izzys-cafe.md';
+
 // Pages sign-in may return to. An allowlist (not raw reflection of `return_to`) keeps the
 // post-OAuth redirect from becoming an open redirect. First entry is the default fallback.
-const RETURN_PATHS = ['/upload', '/recipes/', '/orders/'];
+const RETURN_PATHS = ['/upload', '/recipes/', '/orders/', '/update-menu'];
 const DEFAULT_RETURN = RETURN_PATHS[0];
 const safeReturn = (path: string | null): string =>
   path && RETURN_PATHS.includes(path) ? path : DEFAULT_RETURN;
@@ -87,6 +94,8 @@ export default {
           return await withSession(request, env, (_id, s) => putRecipe(request, env, s));
         case 'DELETE /api/recipe':
           return await withSession(request, env, (_id, s) => deleteRecipe(request, env, s));
+        case 'POST /api/menu':
+          return await withSession(request, env, (_id, s) => putMenu(request, env, s));
         case 'POST /logout':
           return await withSession(request, env, (id) => logout(env, id));
         case 'GET /api/me':
@@ -433,6 +442,38 @@ async function deleteRecipe(request: Request, env: Env, session: Session): Promi
     sha: existing.sha,
     branch: env.BRANCH,
   }, 'delete');
+  return json(env, 200, { ok: true });
+}
+
+// ---- Menu proxy (overwrite the single menu file) --------------------------
+
+// Overwrite the cafe menu markdown. Unlike recipes there's no slug — the target is the fixed
+// MENU_PATH — and it's always an overwrite (the file already exists), so we fetch its sha first.
+// A cheap structural guard rejects payloads that don't look like a menu, so a malformed request
+// can't blank out the file the order form / feed / LED sign all depend on.
+async function putMenu(request: Request, env: Env, session: Session): Promise<Response> {
+  let body: { markdown?: string; message?: string };
+  try {
+    body = (await request.json()) as { markdown?: string; message?: string };
+  } catch {
+    return json(env, 400, { error: 'Invalid JSON body.' });
+  }
+  const markdown = typeof body.markdown === 'string' ? body.markdown : '';
+  // Cheap structural guard so a malformed payload can't blank the file. Tolerant of heading level
+  // and case to match the site parser's wrapper detection (src/lib/cafe-menu.ts).
+  if (!/^#{2,6}\s+menu\s*$/im.test(markdown)) {
+    return json(env, 400, { error: 'Menu content looks malformed (missing a "## Menu" heading).' });
+  }
+
+  const existing = await getExisting(env, session.token, MENU_PATH);
+  const payload: Record<string, unknown> = {
+    message: body.message || 'Update cafe menu',
+    content: b64(markdown),
+    branch: env.BRANCH,
+  };
+  if (existing) payload.sha = existing.sha;
+
+  await commit(env, session.token, 'PUT', MENU_PATH, payload, 'commit');
   return json(env, 200, { ok: true });
 }
 


### PR DESCRIPTION
Adds an unlisted, mobile-friendly **`/update-menu`** editor so the cafe menu can be tweaked from a phone — no more hand-editing markdown and pushing.

## What & why
The menu (`src/content/pages/izzys-cafe.md`) is the single source of truth, baked in at build time and consumed by the order form, the `/izzys-cafe.json` feed, and the dizzyos LED sign. This mirrors the proven `/upload` recipe flow: the page builds the menu markdown client-side and POSTs it to a new **`POST /api/menu`** route on the recipe OAuth Worker, which commits the file after a GitHub sign-in. The GitHub token never touches the browser (opaque session id only). The commit triggers the normal Pages rebuild, so the change propagates everywhere from one source.

## Changes
- **Worker (`worker/src/worker.ts`)** — `POST /api/menu` overwrites the single fixed `MENU_PATH` (hard-coded, never client-derived), gated by the same `withSession`/`ALLOWED_LOGIN` auth as recipes. `/update-menu` added to the OAuth return allowlist; malformed bodies rejected with `400`.
- **`src/lib/cafe-menu.ts`** — export canonical `MENU_SECTIONS` so the editor and order form share one locked section list.
- **`src/pages/update-menu.astro`** — new structured editor over the fixed sections (Drinks/Milks/Syrups/Food). `noindex`, prefilled from the live feed. Guards: Enter adds a row instead of submitting (no accidental commit); an async feed refresh never clobbers in-progress edits.

## Testing
- `npm run build` + Worker `tsc` clean; menu serializer round-trips through the real `parseMenu`.
- Worker auth guards verified (401 no/invalid session, 204 CORS preflight).
- **Full save→commit E2E** run locally against a throwaway branch: session auth → `POST /api/menu` → real GitHub commit landed on the scratch branch with the item correctly serialized; master untouched. Scratch branch + injected session cleaned up after.
- Reviewed via `/simplify` + `/code-review`; the two real findings (Enter-to-submit, edit-wiping race) are fixed.

## Deploy note
The `/api/menu` route goes live only after redeploying the Worker: `cd worker && npx wrangler deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)