### PR TITLE
fix: cache-bust favicon urls with ?v=2, cachemaxxing

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -16,8 +16,8 @@ const { title, description = "Izzy Bennett's personal website — resume, recipe
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="icon" href="/favicon.ico" sizes="any" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg?v=2" />
+    <link rel="icon" href="/favicon.ico?v=2" sizes="any" />
     <meta name="description" content={description} />
     <meta name="generator" content={Astro.generator} />
     <title>{title} · Izzy Bennett</title>

--- a/src/pages/upload.astro
+++ b/src/pages/upload.astro
@@ -46,8 +46,8 @@ const dragHandle =
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="robots" content="noindex, nofollow" />
     <meta name="theme-color" content="#db2777" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="icon" href="/favicon.ico" sizes="any" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg?v=2" />
+    <link rel="icon" href="/favicon.ico?v=2" sizes="any" />
     <title>Add a recipe · Izzy Bennett</title>
   </head>
   <body class="min-h-screen bg-white text-neutral-800 dark:bg-neutral-950 dark:text-neutral-200">


### PR DESCRIPTION
## What & why

The pink favicon is already live in production (`favicon.svg` from #18, regenerated pink `favicon.ico` from #24 — both verified serving pink from GitHub's origin). But browsers cache favicons **very** aggressively: anyone who previously loaded the site has the old black `/favicon.ico` pinned and a normal reload won't evict it.

This appends `?v=2` to the favicon `href`s in `BaseLayout.astro` and `upload.astro` so browsers see a new URL and refetch the (already-pink) icons on the next page load — no manual cache clear needed for returning visitors.

## Changes
- `src/layouts/BaseLayout.astro` — `/favicon.svg?v=2`, `/favicon.ico?v=2`
- `src/pages/upload.astro` — same

## Verify
`npm run build` → both `dist/index.html` and `dist/upload/index.html` emit the `?v=2` links. After deploy, reloading the site pulls the pink icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)