### PR TITLE
fix: unblock Close Kitchen — real User-Agent on the /api/me check

### DIFF
--- a/order-server/main.py
+++ b/order-server/main.py
@@ -99,8 +99,13 @@ def verify_session(authorization: str | None) -> bool:
     closed (returns False) if the header is missing or the Worker is unreachable."""
     if not authorization or not authorization.startswith("Bearer "):
         return False
+    # Send an explicit User-Agent: the Worker sits behind Cloudflare, whose bot protection 403s the
+    # default "Python-urllib/x.y" UA before the request ever reaches the Worker — which would make
+    # this fail closed and the kitchen toggle never work. Any non-bot UA gets through.
     req = urllib.request.Request(
-        f"{RECIPE_API}/api/me", headers={"Authorization": authorization}, method="GET"
+        f"{RECIPE_API}/api/me",
+        headers={"Authorization": authorization, "User-Agent": "izzy-orders/1.0"},
+        method="GET",
     )
     try:
         with urllib.request.urlopen(req, timeout=5) as res:


### PR DESCRIPTION
## Problem

**Close Kitchen never worked.** Clicking it reloads the page (repeated GitHub re-sign-in) but the kitchen stays open.

Root cause, traced end-to-end:
- The `/orders` toggle `POST`s to the Pi's `/status`, which calls `verify_session()` → the recipe Worker's `GET /api/me`.
- `urllib` sends `User-Agent: Python-urllib/3.x`, which **Cloudflare's bot protection 403s at the edge** — the request never reaches the Worker (confirmed: it never shows in `wrangler tail`).
- `verify_session` treats that as failure → `POST /status` returns **401** → the page clears the session and restarts OAuth. Infinite loop.

Verified from the Pi:
| Request | Result |
|---|---|
| `urllib` default UA (`Python-urllib/3.13`) | **403** (Cloudflare-blocked) |
| custom UA (`izzy-orders/1.0`) | **401** (reaches Worker → valid session would be 200) |

## Fix

One line: set an explicit `User-Agent` on the `/api/me` request in `verify_session`. Any non-bot UA gets through.

## Deploy note

The Pi's `izzy-orders-update` timer syncs `master` every ~few minutes, so once this merges the Pi picks it up automatically and restarts the service — then Close Kitchen works (while signed in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)