### PR TITLE
feat: require hot/iced selection on every drink order

### DIFF
--- a/order-server/main.py
+++ b/order-server/main.py
@@ -20,6 +20,7 @@ import urllib.request
 from contextlib import closing
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Literal
 
 from fastapi import FastAPI, Header, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -58,18 +59,24 @@ def init_db() -> None:
         conn.execute(
             """
             CREATE TABLE IF NOT EXISTS orders (
-                id         INTEGER PRIMARY KEY AUTOINCREMENT,
-                name       TEXT NOT NULL,
-                drink      TEXT NOT NULL,
-                milk       TEXT,
-                syrups     TEXT NOT NULL DEFAULT '[]',  -- JSON array
-                notes      TEXT,
-                status     TEXT NOT NULL DEFAULT 'new',
-                created_at TEXT NOT NULL,
-                updated_at TEXT NOT NULL
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                name        TEXT NOT NULL,
+                drink       TEXT NOT NULL,
+                temperature TEXT,  -- 'Hot' | 'Iced' (nullable: rows predate this column)
+                milk        TEXT,
+                syrups      TEXT NOT NULL DEFAULT '[]',  -- JSON array
+                notes       TEXT,
+                status      TEXT NOT NULL DEFAULT 'new',
+                created_at  TEXT NOT NULL,
+                updated_at  TEXT NOT NULL
             )
             """
         )
+        # Migration for DBs created before `temperature` existed — add the column if it's missing so
+        # an in-place server update doesn't need a manual schema change or a wiped orders.db.
+        have = {row["name"] for row in conn.execute("PRAGMA table_info(orders)")}
+        if "temperature" not in have:
+            conn.execute("ALTER TABLE orders ADD COLUMN temperature TEXT")
         # Small key/value store for app state — currently just whether the kitchen is open.
         conn.execute("CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
         conn.commit()
@@ -129,6 +136,10 @@ app.add_middleware(
 
 class OrderIn(BaseModel):
     drink: str = Field(min_length=1, max_length=100)
+    # Hot/iced choice. Required by the /order form (client-side), but kept optional here so a
+    # brief site/Pi version skew during a deploy can't 422 legitimate orders; validated to the two
+    # allowed values when present.
+    temperature: Literal["Hot", "Iced"] | None = None
     name: str = Field(min_length=1, max_length=100)
     milk: str | None = Field(default=None, max_length=100)
     syrups: list[str] = Field(default_factory=list)
@@ -198,10 +209,10 @@ def create_order(order: OrderIn) -> dict:
             raise HTTPException(status_code=403, detail="kitchen is closed")
         cur = conn.execute(
             """
-            INSERT INTO orders (name, drink, milk, syrups, notes, status, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, 'new', ?, ?)
+            INSERT INTO orders (name, drink, temperature, milk, syrups, notes, status, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, 'new', ?, ?)
             """,
-            (name, drink, clean(order.milk), json.dumps(syrups), clean(order.notes), ts, ts),
+            (name, drink, order.temperature, clean(order.milk), json.dumps(syrups), clean(order.notes), ts, ts),
         )
         conn.commit()
         row = conn.execute("SELECT * FROM orders WHERE id = ?", (cur.lastrowid,)).fetchone()

--- a/src/pages/order.astro
+++ b/src/pages/order.astro
@@ -55,6 +55,19 @@ const chipCls =
         </div>
       </fieldset>
 
+      <!-- Temperature (required) — no default, so the customer must actively choose. -->
+      <fieldset>
+        <legend class={labelCls}>Hot or iced? <span class="text-accent-600">*</span></legend>
+        <div class="mt-2 flex flex-wrap gap-2">
+          {['Hot', 'Iced'].map((t) => (
+            <label>
+              <input type="radio" name="temperature" value={t} required class="peer sr-only" />
+              <span class={chipCls}>{t === 'Hot' ? 'Hot 🔥' : 'Iced 🧊'}</span>
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
       {milks.length > 0 && (
         <fieldset>
           <legend class={labelCls}>Milk <span class={optionalCls}>(optional)</span></legend>
@@ -154,11 +167,14 @@ const chipCls =
       if (!kitchenOpen) { setStatus('The kitchen is closed right now.', 'err'); return; }
       const drink = form.querySelector('input[name="drink"]:checked')?.value;
       if (!drink) { setStatus('Pick a drink first.', 'err'); return; }
+      const temperature = form.querySelector('input[name="temperature"]:checked')?.value;
+      if (!temperature) { setStatus('Pick hot or iced first.', 'err'); return; }
       const name = form.name.value.trim();
       if (!name) { setStatus('Add your name first.', 'err'); return; }
 
       const order = {
         drink,
+        temperature,
         name,
         milk: form.querySelector('input[name="milk"]:checked')?.value || undefined,
         syrups: checkedValues('syrup'),
@@ -186,6 +202,8 @@ const chipCls =
         form.querySelectorAll('input[name="syrup"]').forEach((el) => (el.checked = false));
         const noMilk = form.querySelector('input[name="milk"][value=""]');
         if (noMilk) noMilk.checked = true;
+        // Clear temperature so the next order has to choose hot/iced again.
+        form.querySelectorAll('input[name="temperature"]').forEach((el) => (el.checked = false));
         form.name.value = '';
         form.notes.value = '';
       } catch (err) {

--- a/src/pages/order.astro
+++ b/src/pages/order.astro
@@ -59,10 +59,10 @@ const chipCls =
       <fieldset>
         <legend class={labelCls}>Hot or iced? <span class="text-accent-600">*</span></legend>
         <div class="mt-2 flex flex-wrap gap-2">
-          {['Hot', 'Iced'].map((t) => (
+          {[['Hot', '🔥'], ['Iced', '🧊']].map(([value, emoji]) => (
             <label>
-              <input type="radio" name="temperature" value={t} required class="peer sr-only" />
-              <span class={chipCls}>{t === 'Hot' ? 'Hot 🔥' : 'Iced 🧊'}</span>
+              <input type="radio" name="temperature" value={value} required class="peer sr-only" />
+              <span class={chipCls}>{value} {emoji}</span>
             </label>
           ))}
         </div>

--- a/src/pages/orders.astro
+++ b/src/pages/orders.astro
@@ -136,7 +136,9 @@ const colHeadCls = 'text-xs font-semibold uppercase tracking-wide text-neutral-5
 
       const drink = document.createElement('div');
       drink.className = 'font-semibold text-neutral-900 dark:text-neutral-100';
-      drink.textContent = order.drink;
+      // Prefix with the hot/iced choice, e.g. "Iced Latte". Older orders may lack it — fall back to
+      // just the drink name.
+      drink.textContent = order.temperature ? `${order.temperature} ${order.drink}` : order.drink;
       el.appendChild(drink);
 
       const bits = [];


### PR DESCRIPTION
## What

Adds a **required Hot/Iced choice** to the `/order` page, per request — every drink order now has to specify temperature.

- **Form (`order.astro`):** a new "Hot or iced? *" fieldset (🔥 / 🧊) with **no default**, so the customer must actively pick. Validated client-side before submit; cleared after each order so the next one chooses fresh.
- **Backend (`main.py`):** new `temperature` column with an **idempotent `ALTER TABLE` migration** (existing `orders.db` upgrades in place — no wipe). `OrderIn.temperature` is `Literal["Hot","Iced"] | None`. Kept **optional server-side** so a brief site/Pi version skew during rollout can't 422 legitimate orders; the requirement is enforced by the form.
- **Kitchen board (`orders.astro`):** each card prefixes the drink with the choice, e.g. **"Iced Latte"**. Older orders without it fall back to just the drink name.

## Verification

Backend tested against a seeded legacy DB:
- ✅ migration adds the column; pre-existing row still readable (`temperature: null`)
- ✅ Hot/Iced stored and returned
- ✅ invalid value → 422
- ✅ missing value → accepted as null (backward-compat)
- ✅ `npm run build` succeeds (28 pages)

## Deploy

On merge: the site rebuilds (form) and the Pi's `izzy-orders-update` timer pulls `main.py` (backend + migration) within a few minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)