### PR TITLE
fix: crispmaxx the homepage headshot on retina screens

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -20,6 +20,7 @@ import me from '../assets/me.jpeg';
       alt="Izzy"
       width={160}
       height={160}
+      densities={[1, 2, 3]}
       class="h-40 w-40 shrink-0 rounded-full border border-neutral-200 object-cover dark:border-neutral-800"
     />
   </div>


### PR DESCRIPTION
## What

Fixes the blurry homepage avatar reported on https://izzybennett.com.

## Why it was blurry

The `astro:assets` `<Image>` had only `width={160} height={160}`, so the build emitted a single 160×160 webp with no `srcset`. Retina displays (2x/3x — basically every phone and Mac) upscale that to 320–480 physical px, which reads as blur. This predates the new photo; the fresh pic just made it noticeable.

## Fix

One line: `densities={[1, 2, 3]}` on the `<Image>` in `src/pages/index.astro`. The build now emits a srcset with 160/320/480px variants (5/19/38 kB) and the 800×800 source covers 3x without upscaling. Verified in the built `dist/index.html` and eyeballed the 2x webp — sharp.

Merging deploys the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AteGn3P97QAUyq4BgtcSjX