### PR TITLE
fix: cache-bust /update-menu favicon, stale-icon debugmaxxing

### DIFF
--- a/src/pages/update-menu.astro
+++ b/src/pages/update-menu.astro
@@ -43,7 +43,8 @@ const removeBtn =
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="robots" content="noindex, nofollow" />
     <meta name="theme-color" content="#db2777" />
-    <link rel="icon" href="/favicon.ico" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg?v=2" />
+    <link rel="icon" href="/favicon.ico?v=2" sizes="any" />
     <title>Update the menu · Izzy's Cafe</title>
   </head>
   <body class="min-h-screen bg-white text-neutral-800 dark:bg-neutral-950 dark:text-neutral-200">


### PR DESCRIPTION
## what
`/update-menu` was the one page still linking bare `/favicon.ico` — no `?v=2`, no SVG icon link at all. Navigating there flipped the tab icon back to the old cached one. Now it uses the same `favicon.svg?v=2` + `favicon.ico?v=2` pair as `BaseLayout`.

## why it got missed
#27 added `update-menu.astro` with its own `<head>`; the very next commit #28 cache-busted `BaseLayout.astro` and `upload.astro` but skipped the just-added page.

## receipts
- `npm run build` → 31 pages, every built `index.html` now contains `favicon.svg?v=2` (grep sweep, zero stragglers)
- `npm run test` → 29/29 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJV16xk24ATQhUaVmtYR37